### PR TITLE
Fixes forward slashes in README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -104,8 +104,8 @@ constant shorthand for ANSI escape sequences::
 
 or simply by manually printing ANSI sequences from your own code::
 
-    print('/033[31m' + 'some red text')
-    print('/033[30m' # and reset to default color)
+    print('\033[31m' + 'some red text')
+    print('\033[30m' # and reset to default color)
 
 or Colorama can be used happily in conjunction with existing ANSI libraries
 such as Termcolor::


### PR DESCRIPTION
`print('/033[31m'` -> `print('\033[31m'`
