### PR TITLE
Don't wrap stdout/stderr if they are None.

### DIFF
--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -24,10 +24,16 @@ def init(autoreset=False, convert=None, strip=None, wrap=True):
         raise ValueError('wrap=False conflicts with any other arg=True')
 
     global wrapped_stdout, wrapped_stderr
-    sys.stdout = wrapped_stdout = \
-        wrap_stream(orig_stdout, convert, strip, autoreset, wrap)
-    sys.stderr = wrapped_stderr = \
-        wrap_stream(orig_stderr, convert, strip, autoreset, wrap)
+    if sys.stdout is None:
+        wrapped_stdout = None
+    else:
+        sys.stdout = wrapped_stdout = \
+            wrap_stream(orig_stdout, convert, strip, autoreset, wrap)
+    if sys.stderr is None:
+        wrapped_stderr = None
+    else:
+        sys.stderr = wrapped_stderr = \
+            wrap_stream(orig_stderr, convert, strip, autoreset, wrap)
 
     global atexit_done
     if not atexit_done:
@@ -36,13 +42,17 @@ def init(autoreset=False, convert=None, strip=None, wrap=True):
 
 
 def deinit():
-    sys.stdout = orig_stdout
-    sys.stderr = orig_stderr
+    if orig_stdout is not None:
+        sys.stdout = orig_stdout
+    if orig_stderr is not None:
+        sys.stderr = orig_stderr
 
 
 def reinit():
-    sys.stdout = wrapped_stdout
-    sys.stderr = wrapped_stdout
+    if wrapped_stdout is not None:
+        sys.stdout = wrapped_stdout
+    if wrapped_stderr is not None:
+        sys.stderr = wrapped_stderr
 
 
 def wrap_stream(stream, convert, strip, autoreset, wrap):

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -7,7 +7,7 @@ except ImportError:
 
 from mock import patch
 
-from .utils import platform, redirected_output
+from .utils import platform, redirected_output, replace_by_none
 
 from ..initialise import init
 from ..ansitowin32 import StreamWrapper
@@ -49,6 +49,14 @@ class InitTest(TestCase):
         with platform('darwin'):
             init()
             self.assertNotWrapped()
+
+    def testInitDoesntWrapIfNone(self):
+        with replace_by_none():
+            init()
+            # We can't use assertNotWrapped here because replace_by_none
+            # changes stdout/stderr already.
+            self.assertIsNone(sys.stdout)
+            self.assertIsNone(sys.stderr)
 
     def testInitAutoresetOnWrapsOnAllPlatforms(self):
         with platform('darwin'):

--- a/colorama/tests/utils.py
+++ b/colorama/tests/utils.py
@@ -19,3 +19,12 @@ def redirected_output():
     yield
     sys.stdout = orig
 
+@contextmanager
+def replace_by_none():
+    orig_stdout = sys.stdout
+    orig_stderr = sys.stderr
+    sys.stdout = None
+    sys.stderr = None
+    yield
+    sys.stdout = orig_stdout
+    sys.stderr = orig_stderr


### PR DESCRIPTION
Fixes https://code.google.com/p/colorama/issues/detail?id=61
