### PR TITLE
Updated classifiers with supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.1',
         'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Terminals',
     ]
 )


### PR DESCRIPTION
The tests also pass in Python 3.3 and Python 3.4, hence an update to the classifiers.
