### PR TITLE
setup.py: Change url to github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     keywords='color colour terminal text ansi windows crossplatform xplatform',
     author='Jonathan Hartley',
     author_email='tartley@tartley.com',
-    url='https://pypi.python.org/pypi/colorama',
+    url='https://github.com/tartley/colorama',
     license='BSD',
     packages=[NAME],
     # see classifiers http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
The GitHub URL is more useful than the PyPI URL, because this data is most often seen on PyPI.