### PR TITLE
Add context manager for colorama

### DIFF
--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,5 +1,5 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
-from .initialise import init, deinit, reinit
+from .initialise import init, deinit, reinit, colorama_text
 from .ansi import Fore, Back, Style, Cursor
 from .ansitowin32 import AnsiToWin32
 

--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -56,8 +56,10 @@ def deinit():
 @contextlib.contextmanager
 def colorama_text(*args):
     init(*args)
-    yield
-    deinit()
+    try:
+        yield
+    finally:
+        deinit()
 
 def reinit():
     if wrapped_stdout is not None:

--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -18,6 +18,7 @@ atexit_done = False
 def reset_all():
     AnsiToWin32(orig_stdout).reset_all()
 
+
 def init(autoreset=False, convert=None, strip=None, wrap=True):
 
     if not wrap and any([autoreset, convert, strip]):
@@ -54,12 +55,13 @@ def deinit():
 
 
 @contextlib.contextmanager
-def colorama_text(*args):
-    init(*args)
+def colorama_text(*args, **kwargs):
+    init(*args, **kwargs)
     try:
         yield
     finally:
         deinit()
+
 
 def reinit():
     if wrapped_stdout is not None:

--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -1,5 +1,6 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 import atexit
+import contextlib
 import sys
 
 from .ansitowin32 import AnsiToWin32
@@ -16,7 +17,6 @@ atexit_done = False
 
 def reset_all():
     AnsiToWin32(orig_stdout).reset_all()
-
 
 def init(autoreset=False, convert=None, strip=None, wrap=True):
 
@@ -52,6 +52,12 @@ def deinit():
     if orig_stderr is not None:
         sys.stderr = orig_stderr
 
+
+@contextlib.contextmanager
+def colorama_text(*args):
+    init(*args)
+    yield
+    deinit()
 
 def reinit():
     if wrapped_stdout is not None:

--- a/demos/demo.sh
+++ b/demos/demo.sh
@@ -31,3 +31,5 @@ python demo06.py
 
 # demo07.py not shown
 # Demonstrate cursor relative movement: UP, DOWN, FORWARD, and BACK in colorama.CURSOR
+
+python demo08.py

--- a/demos/demo.sh
+++ b/demos/demo.sh
@@ -32,4 +32,5 @@ python demo06.py
 # demo07.py not shown
 # Demonstrate cursor relative movement: UP, DOWN, FORWARD, and BACK in colorama.CURSOR
 
+#Demonstrate the use of a context manager instead of manually using init and deinit
 python demo08.py

--- a/demos/demo08.py
+++ b/demos/demo08.py
@@ -1,0 +1,14 @@
+import fixpath
+from colorama import colorama_text, Fore
+
+
+def main():
+    """automatically reset stdout"""
+    with colorama_text():
+      print Fore.GREEN, 'text is green'
+      print Fore.RESET, 'text is back to normal'
+
+    print 'text is back to stdout'
+
+if __name__ == '__main__':
+    main()

--- a/demos/demo08.py
+++ b/demos/demo08.py
@@ -5,8 +5,8 @@ from colorama import colorama_text, Fore
 def main():
     """automatically reset stdout"""
     with colorama_text():
-      print Fore.GREEN, 'text is green'
-      print Fore.RESET, 'text is back to normal'
+        print Fore.GREEN, 'text is green'
+        print Fore.RESET, 'text is back to normal'
 
     print 'text is back to stdout'
 


### PR DESCRIPTION
This enables you to handle the stdout replacement with a with statement rather than manually keeping track of it... for example:

with colorama_text():
      print Fore.GREEN, 'text is green'
      print Fore.RESET, 'text is back to normal'

print 'text is back to stdout'