### PR TITLE
Fix false-positive for windows detection

### DIFF
--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -56,7 +56,7 @@ class AnsiToWin32(object):
         self.stream = StreamWrapper(wrapped, self)
 
         on_windows = os.name == 'nt'
-        on_emulated_windows = on_windows and 'TERM' in os.environ
+        on_emulated_windows = on_windows and 'TERM' in os.environ and os.environ['TERM'] != 'cygwin'
 
         # should we strip ANSI sequences from our output?
         if strip is None:


### PR DESCRIPTION
I'm using bash on Windows as my main console (via Cygwin/[Git Bash](https://git-for-windows.github.io/)). However, colorama treats every system that has `$TERM` defined as an emulated Windows - Cygwin environments should be excluded from that.

Thanks for the great work you're doing here! :smiley: