### PR TITLE
Add check if orig_stdout is not None before calling AnsiToWin32::reset_all()

### DIFF
--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -16,7 +16,8 @@ atexit_done = False
 
 
 def reset_all():
-    AnsiToWin32(orig_stdout).reset_all()
+    if orig_stdout:
+        AnsiToWin32(orig_stdout).reset_all()
 
 
 def init(autoreset=False, convert=None, strip=None, wrap=True):


### PR DESCRIPTION
# Description
When calling ```AnsiToWin32(orig_stdout).reset_all()``` inside ```reset_all()``` function (https://github.com/tartley/colorama/blob/master/colorama/initialise.py#L18) we assume that ```orig_stdout``` is not None, which is not true for all cases.

This causes issues, example below:
```
$ cd python-package-sources
$ coverage -x setup.py test
...
----------------------------------------------------------------------
Ran 15 tests in 0.013s

OK
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "C:\Python27\lib\atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "C:\Python27\lib\site-packages\colorama\initialise.py", line 18, in reset_all
    AnsiToWin32(orig_stdout).reset_all()
TypeError: 'NoneType' object is not callable
Error in sys.exitfunc:
Traceback (most recent call last):
  File "C:\Python27\lib\atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "C:\Python27\lib\site-packages\colorama\initialise.py", line 18, in reset_all
    AnsiToWin32(orig_stdout).reset_all()
TypeError: 'NoneType' object is not callable
```