### PR TITLE
Check for 'closed' attribute on 'wrapped' in AnsiToWin32

### DIFF
--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -64,12 +64,16 @@ class AnsiToWin32(object):
 
         # should we strip ANSI sequences from our output?
         if strip is None:
-            strip = conversion_supported or (not wrapped.closed and not is_a_tty(wrapped))
+            strip = conversion_supported or (
+                hasattr(wrapped, 'closed') and not wrapped.closed and not
+                is_a_tty(wrapped))
         self.strip = strip
 
         # should we should convert ANSI sequences into win32 calls?
         if convert is None:
-            convert = conversion_supported and not wrapped.closed and is_a_tty(wrapped)
+            convert = (conversion_supported and
+                       hasattr(wrapped, 'closed') and not
+                       wrapped.closed and is_a_tty(wrapped))
         self.convert = convert
 
         # dict of ansi codes to win32 functions and parameters

--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -166,7 +166,10 @@ class AnsiToWin32Test(TestCase):
     def test_wrap_shouldnt_raise_on_closed_orig_stdout(self):
         stream = StringIO()
         stream.close()
-        converter = AnsiToWin32(stream)
+        AnsiToWin32(stream)
+
+    def test_wrap_shouldnt_raise_on_missing_closed_attrib(self):
+        AnsiToWin32(object())
 
     def testExtractParams(self):
         stream = AnsiToWin32(Mock())


### PR DESCRIPTION
Otherwise colorama might cause crashes when used in Vim (https://github.com/davidhalter/jedi-vim/issues/522#issuecomment-173327758) or Neovim (https://github.com/davidhalter/jedi-vim/issues/522#issue-125927394).

