### PR TITLE
Enables color on stderr when only stdout is redirected to file

### DIFF
--- a/colorama/win32.py
+++ b/colorama/win32.py
@@ -94,12 +94,14 @@ else:
         STDERR: _GetStdHandle(STDERR),
     }
 
-    def winapi_test():
-        handle = handles[STDOUT]
+    def _winapi_test(handle):
         csbi = CONSOLE_SCREEN_BUFFER_INFO()
         success = _GetConsoleScreenBufferInfo(
             handle, byref(csbi))
         return bool(success)
+
+    def winapi_test():
+        return any(_winapi_test(h) for h in handles.values())
 
     def GetConsoleScreenBufferInfo(stream_id=STDOUT):
         handle = handles[stream_id]


### PR DESCRIPTION
Fixes #95.

Tests fail locally for me even without these changes and I couldn't find any tests for `winapi_test()`, so I'm not sure if this PR is complete.  Let me know if anything is missing, I'll follow up!