### PR TITLE
avoid ansi-escape replacing inside eclipse-pydev

### DIFF
--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -8,6 +8,7 @@ from .winterm import WinTerm, WinColor, WinStyle
 from .win32 import windll, winapi_test
 
 
+INSIDE_PYDEV = 'sitecustomize' in sys.modules #for avoid ansi-escape replacing when runngin inside eclipse-pydev
 winterm = None
 if windll is not None:
     winterm = WinTerm()
@@ -164,11 +165,12 @@ class AnsiToWin32(object):
         '''
         cursor = 0
         text = self.convert_osc(text)
-        for match in self.ANSI_CSI_RE.finditer(text):
-            start, end = match.span()
-            self.write_plain_text(text, cursor, start)
-            self.convert_ansi(*match.groups())
-            cursor = end
+        if not INSIDE_PYDEV: #avoid ansi-escape replacing when inside eclipse-pydev
+            for match in self.ANSI_CSI_RE.finditer(text):
+                start, end = match.span()
+                self.write_plain_text(text, cursor, start)
+                self.convert_ansi(*match.groups())
+                cursor = end
         self.write_plain_text(text, cursor, len(text))
 
 


### PR DESCRIPTION
avoid conflicting colorama with the recommended eclipse plugin (ansi-escape) by pydev author that can enable color in pydev-console
it's make both running code in terminal & eclipse console can show the correct color
![image](https://cloud.githubusercontent.com/assets/1678529/19262496/7ede0ff0-8fc1-11e6-8b80-df1652dcdac6.png)
