### PR TITLE
Adding new print helper function (Word) in ansi module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,14 @@ constant shorthand for ANSI escape sequences:
     print('\033[31m' + 'some red text')
     print('\033[30m') # and reset to default color
 
+...or by using ``Word()`` when you want to use ``.format()`` like this:
+
+.. code-block:: python
+
+    from colorama import Fore, Back, Style, Word
+    print('This {} will be formatted'.format(Word('word', fore=Fore.BLACK,
+                                             back=Back.WHITE, style=Style.DIM)))
+
 ...or, Colorama can be used happily in conjunction with existing ANSI libraries
 such as Termcolor:
 

--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 from .initialise import init, deinit, reinit, colorama_text
-from .ansi import Fore, Back, Style, Cursor
+from .ansi import Fore, Back, Style, Cursor, Word
 from .ansitowin32 import AnsiToWin32
 
 __version__ = '0.3.7'

--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -21,6 +21,15 @@ def clear_screen(mode=2):
 def clear_line(mode=2):
     return CSI + str(mode) + 'K'
 
+def Word(word, fore=None, back=None, style=None):
+    ret = str(word) + code_to_chars(AnsiStyle.RESET_ALL)
+    if fore is not None:
+        ret = fore + ret
+    if back is not None:
+        ret = back + ret
+    if style is not None:
+        ret = style + ret
+    return ret
 
 class AnsiCodes(object):
     def __init__(self):

--- a/colorama/tests/ansi_test.py
+++ b/colorama/tests/ansi_test.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from unittest import TestCase, main
 
-from ..ansi import Fore, Back, Style
+from ..ansi import Fore, Back, Style, Word
 from ..ansitowin32 import AnsiToWin32
 
 
@@ -74,7 +74,19 @@ class AnsiTest(TestCase):
         self.assertEqual(Style.DIM, '\033[2m')
         self.assertEqual(Style.NORMAL, '\033[22m')
         self.assertEqual(Style.BRIGHT, '\033[1m')
-
+    
+    def testWord(self):
+        self.assertEqual(Word('word', fore=Fore.WHITE, back=Back.BLACK, style=Style.DIM),
+                              '\033[2m\033[40m\033[37mword\033[0m')
+        self.assertEqual(Word('word', fore=Fore.WHITE, back=Back.BLACK),
+                         '\033[40m\033[37mword\033[0m')
+        self.assertEqual(Word('word', fore=Fore.WHITE, style=Style.DIM),
+                         '\033[2m\033[37mword\033[0m')
+        self.assertEqual(Word('word', back=Back.BLACK, style=Style.DIM),
+                         '\033[2m\033[40mword\033[0m')
+        self.assertEqual(Word('word', fore=Fore.WHITE), '\033[37mword\033[0m')
+        self.assertEqual(Word('word', back=Back.BLACK), '\033[40mword\033[0m')
+        self.assertEqual(Word('word', style=Style.DIM), '\033[2mword\033[0m')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Adding new function that can help formatting strings when you try to use print with .format (sometimes it's much simpler than performing multiple printing or writing own functions for this. Example is inside new README.rst file. There are also some additional tests for this functionality.