### PR TITLE
Provide pass-through ANSI on Windows 10 powershell

### DIFF
--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -21,7 +21,7 @@ def is_a_tty(stream):
     return hasattr(stream, 'isatty') and stream.isatty()
 
 
-def check_win_10_ansi_support():
+def check_windows_ansi_support():
     try:
         import winreg
     except ImportError:
@@ -87,16 +87,16 @@ class AnsiToWin32(object):
         conversion_supported = on_windows and winapi_test()
 
         # Does this version of Win 10 support ANSI?
-        win_10_ansi_support = on_windows and check_win_10_ansi_support()
+        windows_ansi_support = on_windows and check_windows_ansi_support()
 
         # should we strip ANSI sequences from our output?
-        if strip is None and not win_10_ansi_support:
-            strip = conversion_supported or (not is_stream_closed(wrapped) and not is_a_tty(wrapped))
+        if strip is None:
+            strip = conversion_supported or not windows_ansi_support or (not is_stream_closed(wrapped) and not is_a_tty(wrapped))
         self.strip = strip
 
         # should we should convert ANSI sequences into win32 calls?
-        if convert is None and not win_10_ansi_support:
-            convert = conversion_supported and not is_stream_closed(wrapped) and is_a_tty(wrapped)
+        if convert is None:
+            convert = not windows_ansi_support or (conversion_supported and not is_stream_closed(wrapped) and is_a_tty(wrapped))
         self.convert = convert
 
         # dict of ansi codes to win32 functions and parameters

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -22,7 +22,10 @@ def is_a_tty(stream):
 
 
 def check_win_10_ansi_support():
-    import winreg
+    try:
+        import winreg
+    except ImportError:
+        return False
 
     # Check the registry for release ID
     key = r"SOFTWARE\Microsoft\Windows NT\CurrentVersion"

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,9 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Topic :: Terminals',
-    ]
+    ],
+extras_require={
+    ':sys_platform=="win32"': ['psutil'],
+    },
 )
 


### PR DESCRIPTION
This provides pass-thru to ANSI codes on new enough Windows 10 versions, and to Powershell only. It does this by using `psutil` to check the process name that is running python, and if that matches `powershell.exe`, ANSI pass-thru is enabled.

This does add `psutil` as a dependency on Windows.

Closes #105 

Basic local testing on both Python 2.7 and Python 3.6