### PR TITLE
Drop EOL Python 2.5, 2.6, 3.1, 3.2 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,10 @@
 language: python
-env:
-  - unittest=unittest
-    testbin=unittest
 python:
   - "2.7"
   - "3.6"
   - "3.5"
   - "3.4"
-  - "3.3"
-  - "3.2"
 sudo: false # Use container-based infrastructure
 install:
-  - "if [ $unittest = unittest2 ]; then pip install unittest2; fi"
   - "pip install mock"
-script: "python -m $testbin discover -p *_test.py"
-matrix:
-  include:
-    - python: "2.6"
-      env:
-        - unittest=unittest2
-          testbin=unittest2.__main__
+script: "python -m unittest discover -p *_test.py"

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
     :target: https://pypi.python.org/pypi/colorama/
     :alt: Latest Version
 
+.. image:: https://img.shields.io/pypi/pyversions/colorama.svg
+    :target: https://pypi.python.org/pypi/colorama
+    :alt: Supported Python versions
+
 .. image:: https://travis-ci.org/tartley/colorama.svg?branch=master
     :target: https://travis-ci.org/tartley/colorama
     :alt: Build Status
@@ -67,8 +71,7 @@ Copyright Jonathan Hartley 2013. BSD 3-Clause license; see LICENSE file.
 Dependencies
 ============
 
-None, other than Python. Tested on Python 2.5.5, 2.6.5, 2.7, 3.1.2, 3.2, 3.3,
-3.4, 3.5 and 3.6.
+None, other than Python. Tested on Python 2.7, 3.4, 3.5 and 3.6.
 
 Usage
 =====
@@ -298,9 +301,7 @@ Help and fixes welcome!
 Running tests requires:
 
 - Michael Foord's ``mock`` module to be installed.
-- Tests are written using 2010-era updates to ``unittest``, and require
-  Python 2.7 or greater, OR to have Michael Foord's ``unittest2`` module
-  installed.
+- Tests are written using 2010-era updates to ``unittest``
 
 To run tests::
 

--- a/colorama/tests/ansi_test.py
+++ b/colorama/tests/ansi_test.py
@@ -1,13 +1,9 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 import sys
-try:
-    from unittest2 import TestCase, main
-except ImportError:
-    from unittest import TestCase, main
+from unittest import TestCase, main
 
-from ..ansi import Fore, Back, Style
+from ..ansi import Back, Fore, Style
 from ..ansitowin32 import AnsiToWin32
-
 
 stdout_orig = sys.stdout
 stderr_orig = sys.stderr
@@ -78,4 +74,3 @@ class AnsiTest(TestCase):
 
 if __name__ == '__main__':
     main()
-

--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -6,20 +6,12 @@ except ImportError:
     # python2
     import StringIO
 
-try:
-    # with unittest2 installed, presumably is Python <= 2.6
-    from unittest2 import TestCase, main
-except ImportError:
-    # without unittest2 installed, hopefully is Python > 2.6
-    from unittest import TestCase, main
+from unittest import TestCase, main
 
 from mock import Mock, patch
 
-from .utils import osname
-
-from ..ansi import Style
 from ..ansitowin32 import AnsiToWin32, StreamWrapper
-
+from .utils import osname
 
 
 class StreamWrapperTest(TestCase):
@@ -205,4 +197,3 @@ class AnsiToWin32Test(TestCase):
 
 if __name__ == '__main__':
     main()
-

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -1,17 +1,13 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+import os
 import sys
-try:
-    from unittest2 import TestCase, main
-except ImportError:
-    from unittest import TestCase, main
+from unittest import TestCase, main
 
 from mock import patch
 
-from .utils import osname, redirected_output, replace_by_none
-
-from ..initialise import init
 from ..ansitowin32 import StreamWrapper
-import os
+from ..initialise import init
+from .utils import osname, redirected_output, replace_by_none
 
 orig_stdout = sys.stdout
 orig_stderr = sys.stderr
@@ -125,4 +121,3 @@ class InitTest(TestCase):
 
 if __name__ == '__main__':
     main()
-

--- a/colorama/tests/winterm_test.py
+++ b/colorama/tests/winterm_test.py
@@ -1,11 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
-from mock import Mock, patch
 import sys
-try:
-    from unittest2 import TestCase, main, skipUnless
-except ImportError:
-    from unittest import TestCase, main, skipUnless
+from unittest import TestCase, main, skipUnless
 
+from mock import Mock, patch
 
 from ..winterm import WinColor, WinStyle, WinTerm
 
@@ -129,4 +126,3 @@ class WinTermTest(TestCase):
 
 if __name__ == '__main__':
     main()
-

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     url='https://github.com/tartley/colorama',
     license='BSD',
     packages=[NAME],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     # see classifiers http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -54,13 +55,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.5',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 deps = pytest
        pytest-cov
        mock
-       unittest2
 commands = py.test --cov colorama {posargs:colorama/tests}


### PR DESCRIPTION
Fixes #153, which so far has one 👍  and no objections.

Also add `python_requires` to setup.py to help pip.