### PR TITLE
Prevent file stream from being incorrectly wrapped on Pycharm

### DIFF
--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -13,17 +13,6 @@ if windll is not None:
     winterm = WinTerm()
 
 
-def is_stream_closed(stream):
-    return not hasattr(stream, 'closed') or stream.closed
-
-
-def is_a_tty(stream):
-    if 'PYCHARM_HOSTED' in os.environ:
-        if stream is not None and (stream is sys.__stdout__ or stream is sys.__stderr__):
-            return True
-    return (hasattr(stream, 'isatty') and stream.isatty())
-
-
 class StreamWrapper(object):
     '''
     Wraps a stream (such as stdout), acting as a transparent proxy for all
@@ -43,7 +32,17 @@ class StreamWrapper(object):
         self.__convertor.write(text)
 
     def isatty(self):
-        return is_a_tty(self.__wrapped)
+        stream = self.__wrapped
+        if 'PYCHARM_HOSTED' in os.environ:
+            if stream is not None and (stream is sys.__stdout__ or stream is sys.__stderr__):
+                return True
+        return (hasattr(stream, 'isatty') and stream.isatty())
+
+    @property
+    def closed(self):
+        stream = self.__wrapped
+        return not hasattr(stream, 'closed') or stream.closed
+
 
 class AnsiToWin32(object):
     '''
@@ -73,12 +72,12 @@ class AnsiToWin32(object):
 
         # should we strip ANSI sequences from our output?
         if strip is None:
-            strip = conversion_supported or (not is_stream_closed(wrapped) and not is_a_tty(wrapped))
+            strip = conversion_supported or (not self.stream.closed and not self.stream.isatty())
         self.strip = strip
 
         # should we should convert ANSI sequences into win32 calls?
         if convert is None:
-            convert = conversion_supported and not is_stream_closed(wrapped) and is_a_tty(wrapped)
+            convert = conversion_supported and not self.stream.closed and self.stream.isatty()
         self.convert = convert
 
         # dict of ansi codes to win32 functions and parameters
@@ -154,7 +153,7 @@ class AnsiToWin32(object):
     def reset_all(self):
         if self.convert:
             self.call_win32('m', (0,))
-        elif not self.strip and not is_stream_closed(self.wrapped):
+        elif not self.strip and not self.stream.closed:
             self.wrapped.write(Style.RESET_ALL)
 
 

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -19,7 +19,8 @@ def is_stream_closed(stream):
 
 def is_a_tty(stream):
     if 'PYCHARM_HOSTED' in os.environ:
-        return True
+        if stream is not None and (stream is sys.__stdout__ or stream is sys.__stderr__):
+            return True
     return (hasattr(stream, 'isatty') and stream.isatty())
 
 
@@ -41,6 +42,8 @@ class StreamWrapper(object):
     def write(self, text):
         self.__convertor.write(text)
 
+    def isatty(self):
+        return is_a_tty(self.__wrapped)
 
 class AnsiToWin32(object):
     '''

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -7,7 +7,7 @@ from mock import patch
 
 from ..ansitowin32 import StreamWrapper
 from ..initialise import init
-from .utils import osname, redirected_output, replace_by_none
+from .utils import osname, redirected_output, replace_by
 
 orig_stdout = sys.stdout
 orig_stderr = sys.stderr
@@ -55,9 +55,9 @@ class InitTest(TestCase):
             self.assertNotWrapped()
 
     def testInitDoesntWrapIfNone(self):
-        with replace_by_none():
+        with replace_by(None):
             init()
-            # We can't use assertNotWrapped here because replace_by_none
+            # We can't use assertNotWrapped here because replace_by(None)
             # changes stdout/stderr already.
             self.assertIsNone(sys.stdout)
             self.assertIsNone(sys.stderr)

--- a/colorama/tests/isatty_test.py
+++ b/colorama/tests/isatty_test.py
@@ -1,0 +1,54 @@
+# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+import sys
+from unittest import TestCase, main
+
+from ..ansitowin32 import is_a_tty, AnsiToWin32
+from .utils import pycharm, replace_by, replace_original_by, StreamTTY, StreamNonTTY
+
+
+class IsattyTest(TestCase):
+
+    def test_TTY(self):
+        tty = StreamTTY()
+        self.assertTrue(is_a_tty(tty))
+        with pycharm():
+            self.assertTrue(is_a_tty(tty))
+
+    def test_nonTTY(self):
+        non_tty = StreamNonTTY()
+        self.assertFalse(is_a_tty(non_tty))
+        with pycharm():
+            self.assertFalse(is_a_tty(non_tty))
+
+    def test_withPycharm(self):
+        with pycharm():
+            self.assertTrue(is_a_tty(sys.stderr))
+            self.assertTrue(is_a_tty(sys.stdout))
+
+    def test_withPycharmTTYOverride(self):
+        tty = StreamTTY()
+        with pycharm(), replace_by(tty):
+            self.assertTrue(is_a_tty(tty))
+
+    def test_withPycharmNonTTYOverride(self):
+        non_tty = StreamNonTTY()
+        with pycharm(), replace_by(non_tty):
+            self.assertFalse(is_a_tty(non_tty))
+
+    def test_withPycharmNoneOverride(self):
+        with pycharm():
+            with replace_by(None), replace_original_by(None):
+                self.assertFalse(is_a_tty(None))
+                self.assertFalse(is_a_tty(StreamNonTTY()))
+                self.assertTrue(is_a_tty(StreamTTY()))
+
+    def test_withPycharmStreamWrapped(self):
+        with pycharm():
+            self.assertTrue(is_a_tty(AnsiToWin32(StreamTTY()).stream))
+            self.assertFalse(is_a_tty(AnsiToWin32(StreamNonTTY()).stream))
+            self.assertTrue(is_a_tty(AnsiToWin32(sys.stdout).stream))
+            self.assertTrue(is_a_tty(AnsiToWin32(sys.stderr).stream))
+
+
+if __name__ == '__main__':
+    main()

--- a/colorama/tests/isatty_test.py
+++ b/colorama/tests/isatty_test.py
@@ -2,9 +2,12 @@
 import sys
 from unittest import TestCase, main
 
-from ..ansitowin32 import is_a_tty, AnsiToWin32
+from ..ansitowin32 import StreamWrapper, AnsiToWin32
 from .utils import pycharm, replace_by, replace_original_by, StreamTTY, StreamNonTTY
 
+
+def is_a_tty(stream):
+    return StreamWrapper(stream, None).isatty()
 
 class IsattyTest(TestCase):
 
@@ -44,10 +47,10 @@ class IsattyTest(TestCase):
 
     def test_withPycharmStreamWrapped(self):
         with pycharm():
-            self.assertTrue(is_a_tty(AnsiToWin32(StreamTTY()).stream))
-            self.assertFalse(is_a_tty(AnsiToWin32(StreamNonTTY()).stream))
-            self.assertTrue(is_a_tty(AnsiToWin32(sys.stdout).stream))
-            self.assertTrue(is_a_tty(AnsiToWin32(sys.stderr).stream))
+            self.assertTrue(AnsiToWin32(StreamTTY()).stream.isatty())
+            self.assertFalse(AnsiToWin32(StreamNonTTY()).stream.isatty())
+            self.assertTrue(AnsiToWin32(sys.stdout).stream.isatty())
+            self.assertTrue(AnsiToWin32(sys.stderr).stream.isatty())
 
 
 if __name__ == '__main__':

--- a/colorama/tests/utils.py
+++ b/colorama/tests/utils.py
@@ -1,9 +1,18 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 from contextlib import contextmanager
+from io import StringIO
 import sys
 import os
 
 from mock import Mock
+
+class StreamTTY(StringIO):
+    def isatty(self):
+        return True
+
+class StreamNonTTY(StringIO):
+    def isatty(self):
+        return False
 
 @contextmanager
 def osname(name):
@@ -21,11 +30,29 @@ def redirected_output():
     sys.stdout = orig
 
 @contextmanager
-def replace_by_none():
+def replace_by(stream):
     orig_stdout = sys.stdout
     orig_stderr = sys.stderr
-    sys.stdout = None
-    sys.stderr = None
+    sys.stdout = stream
+    sys.stderr = stream
     yield
     sys.stdout = orig_stdout
     sys.stderr = orig_stderr
+
+@contextmanager
+def replace_original_by(stream):
+    orig_stdout = sys.__stdout__
+    orig_stderr = sys.__stderr__
+    sys.__stdout__ = stream
+    sys.__stderr__ = stream
+    yield
+    sys.__stdout__ = orig_stdout
+    sys.__stderr__ = orig_stderr
+
+@contextmanager
+def pycharm():
+    os.environ["PYCHARM_HOSTED"] = "1"
+    non_tty = StreamNonTTY()
+    with replace_by(non_tty), replace_original_by(non_tty):
+        yield
+    del os.environ["PYCHARM_HOSTED"]


### PR DESCRIPTION
Hi.

This is related to a comment I left some days ago: https://github.com/tartley/colorama/pull/163#issuecomment-388280675

I think this is quite important to **only** wrap `stdout` and `stderr` on Pycharm, rather than **any** stream. Think for example of a logging module which relies on `colorama` to wrap arbitrary handler's stream. :wink:


