### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the [metadata] section in the setup.cfg file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Helps project comply with its own license:

> Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.