### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 .. image:: https://img.shields.io/pypi/v/colorama.svg
-    :target: https://pypi.python.org/pypi/colorama/
+    :target: https://pypi.org/project/colorama/
     :alt: Latest Version
 
 .. image:: https://img.shields.io/pypi/pyversions/colorama.svg
-    :target: https://pypi.python.org/pypi/colorama
+    :target: https://pypi.org/project/colorama/
     :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/tartley/colorama.svg?branch=master
@@ -11,7 +11,7 @@
     :alt: Build Status
 
 Download and docs:
-    http://pypi.python.org/pypi/colorama
+    https://pypi.org/project/colorama/
 Source code & Development:
     https://github.com/tartley/colorama
 
@@ -30,8 +30,8 @@ Colorama does nothing.
 
 Colorama also provides some shortcuts to help generate ANSI sequences
 but works fine in conjunction with any other ANSI sequence generation library,
-such as the venerable Termcolor (http://pypi.python.org/pypi/termcolor)
-or the fabulous Blessings (https://pypi.python.org/pypi/blessings).
+such as the venerable Termcolor (https://pypi.org/project/termcolor/)
+or the fabulous Blessings (https://pypi.org/project/blessings/).
 
 This has the upshot of providing a simple cross-platform API for printing
 colored terminal text from Python, and has the happy side-effect that existing

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     license='BSD',
     packages=[NAME],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    # see classifiers http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    # see classifiers https://pypi.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html