### PR TITLE
Remove unused "except ImportError"

### DIFF
--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -1,11 +1,5 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
-try:
-    # python3
-    from io import StringIO
-except ImportError:
-    # python2
-    import StringIO
-
+from io import StringIO
 from unittest import TestCase, main
 
 from mock import Mock, patch


### PR DESCRIPTION
The `io` module is available on all supported Pythons. It was added in version 2.6. The fallback is never used. For additional details on the module, see:

https://docs.python.org/3/library/io.html
https://docs.python.org/2/library/io.html