### PR TITLE
Replace calls to dict() with dict literals

### DIFF
--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -136,7 +136,7 @@ class AnsiToWin32(object):
                 AnsiBack.LIGHTCYAN_EX: (winterm.back, WinColor.CYAN, True),
                 AnsiBack.LIGHTWHITE_EX: (winterm.back, WinColor.GREY, True),
             }
-        return dict()
+        return {}
 
     def write(self, text):
         if self.strip or self.convert:
@@ -208,7 +208,7 @@ class AnsiToWin32(object):
                     func_args = self.win32_calls[param]
                     func = func_args[0]
                     args = func_args[1:]
-                    kwargs = dict(on_stderr=self.on_stderr)
+                    kwargs = {'on_stderr': self.on_stderr}
                     func(*args, **kwargs)
         elif command in 'J':
             winterm.erase_screen(params[0], on_stderr=self.on_stderr)


### PR DESCRIPTION
Literals are more idiomatic Python and are always (very slightly) faster.