### PR TITLE
Add generated testing directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.pyc
 *.egg-info
+.coverage
+.pytest_cache/
+.tox/
 MANIFEST
 dist
 tags


### PR DESCRIPTION
The directories are auto-generated during the command "tox" and should
not be committed to version control.