### PR TITLE
Include tests in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include LICENSE.txt CHANGELOG.rst
 recursive-include demos *.py *.bat *.sh
+graft tests
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
Hi,
We at Gentoo rely on PyPI tarballs to build docs and run tests, could you include them in future releases so that we don't have to use GitHub's tarballs?