### PR TITLE
Remove discussion of unmaintained nose for running tests

### DIFF
--- a/README-hacking.md
+++ b/README-hacking.md
@@ -30,10 +30,6 @@ scripts.
 The Makefile is self-documenting, so 'make' with no args will describe each
 target.
 
-If you use nose to run the tests, you must pass the ``-s`` flag; otherwise,
-``nosetests`` applies its own proxy to ``stdout``, which confuses the unit
-tests.
-
 ## Release checklist
 
 1. Check the CHANGELOG is updated with everything since the last release.


### PR DESCRIPTION
The nose project has ceased development. The last commit is from Mar 3,
2016. From their docs page:

https://nose.readthedocs.io/

> Note to Users
>
> Nose has been in maintenance mode for the past several years and will
> likely cease without a new person/team to take over maintainership.
> New projects should consider using Nose2, py.test, or just plain
> unittest/unittest2.