### PR TITLE
Use the recommended test command in tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.pyc
 *.egg-info
 .coverage
-.pytest_cache/
 .tox/
 MANIFEST
 dist

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,5 @@
 envlist = py27, py34, py35, py36, pypy
 
 [testenv]
-deps = pytest
-       pytest-cov
-       mock
-commands = py.test --cov colorama {posargs:colorama/tests}
+deps = mock
+commands = python -m unittest discover -p *_test.py


### PR DESCRIPTION
Running the command `tox` now tests in the same way as Travis CI and as
recommended in the docs. Makes it simpler to recreate an identical test
environment locally.