### PR TITLE
Remove unnecessary distutils fallback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,7 @@ from __future__ import with_statement
 
 import os
 import re
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 
 NAME = 'colorama'


### PR DESCRIPTION
The distutils fallback isn't necessary. setuptools should be available on all modern, supported Pythons.