### PR TITLE
Rename .closed property to avoid recursion

### DIFF
--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -48,7 +48,8 @@ class StreamWrapper(object):
         return (hasattr(stream, 'isatty') and stream.isatty())
 
     @property
-    def closed(self):
+    def is_closed(self):
+        print('Checking!')
         stream = self.__wrapped
         try:
             return stream.closed
@@ -84,12 +85,12 @@ class AnsiToWin32(object):
 
         # should we strip ANSI sequences from our output?
         if strip is None:
-            strip = conversion_supported or (not self.stream.closed and not self.stream.isatty())
+            strip = conversion_supported or (not self.stream.is_closed and not self.stream.isatty())
         self.strip = strip
 
         # should we should convert ANSI sequences into win32 calls?
         if convert is None:
-            convert = conversion_supported and not self.stream.closed and self.stream.isatty()
+            convert = conversion_supported and not self.stream.is_closed and self.stream.isatty()
         self.convert = convert
 
         # dict of ansi codes to win32 functions and parameters
@@ -165,7 +166,7 @@ class AnsiToWin32(object):
     def reset_all(self):
         if self.convert:
             self.call_win32('m', (0,))
-        elif not self.strip and not self.stream.closed:
+        elif not self.strip and not self.stream.is_closed:
             self.wrapped.write(Style.RESET_ALL)
 
 

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -49,7 +49,6 @@ class StreamWrapper(object):
 
     @property
     def is_closed(self):
-        print('Checking!')
         stream = self.__wrapped
         try:
             return stream.closed

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -48,9 +48,12 @@ class StreamWrapper(object):
         return (hasattr(stream, 'isatty') and stream.isatty())
 
     @property
-    def is_closed(self):
+    def closed(self):
         stream = self.__wrapped
-        return not hasattr(stream, 'closed') or stream.closed
+        try:
+            return stream.closed
+        except AttributeError:
+            return True
 
 
 class AnsiToWin32(object):
@@ -81,12 +84,12 @@ class AnsiToWin32(object):
 
         # should we strip ANSI sequences from our output?
         if strip is None:
-            strip = conversion_supported or (not self.stream.is_closed and not self.stream.isatty())
+            strip = conversion_supported or (not self.stream.closed and not self.stream.isatty())
         self.strip = strip
 
         # should we should convert ANSI sequences into win32 calls?
         if convert is None:
-            convert = conversion_supported and not self.stream.is_closed and self.stream.isatty()
+            convert = conversion_supported and not self.stream.closed and self.stream.isatty()
         self.convert = convert
 
         # dict of ansi codes to win32 functions and parameters
@@ -162,7 +165,7 @@ class AnsiToWin32(object):
     def reset_all(self):
         if self.convert:
             self.call_win32('m', (0,))
-        elif not self.strip and not self.stream.is_closed:
+        elif not self.strip and not self.stream.closed:
             self.wrapped.write(Style.RESET_ALL)
 
 

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -48,7 +48,7 @@ class StreamWrapper(object):
         return (hasattr(stream, 'isatty') and stream.isatty())
 
     @property
-    def closed(self):
+    def is_closed(self):
         stream = self.__wrapped
         return not hasattr(stream, 'closed') or stream.closed
 
@@ -81,12 +81,12 @@ class AnsiToWin32(object):
 
         # should we strip ANSI sequences from our output?
         if strip is None:
-            strip = conversion_supported or (not self.stream.closed and not self.stream.isatty())
+            strip = conversion_supported or (not self.stream.is_closed and not self.stream.isatty())
         self.strip = strip
 
         # should we should convert ANSI sequences into win32 calls?
         if convert is None:
-            convert = conversion_supported and not self.stream.closed and self.stream.isatty()
+            convert = conversion_supported and not self.stream.is_closed and self.stream.isatty()
         self.convert = convert
 
         # dict of ansi codes to win32 functions and parameters
@@ -162,7 +162,7 @@ class AnsiToWin32(object):
     def reset_all(self):
         if self.convert:
             self.call_win32('m', (0,))
-        elif not self.strip and not self.stream.closed:
+        elif not self.strip and not self.stream.is_closed:
             self.wrapped.write(Style.RESET_ALL)
 
 


### PR DESCRIPTION
Re: issue #196, this PR changes one aspect of #164 that was causing me problems.

When using `autoreset=True`, [this check](https://github.com/tartley/colorama/blob/c11da6f6004bba0fabb2f7a68a06f53baeeb6b74/colorama/ansitowin32.py#L165) seems to happen over and over. [This method](https://github.com/tartley/colorama/blob/c11da6f6004bba0fabb2f7a68a06f53baeeb6b74/colorama/ansitowin32.py#L53) is calling itself, since `StreamWrapper` can be the stream.

Adding a print statement [here](https://github.com/tartley/colorama/blob/c11da6f6004bba0fabb2f7a68a06f53baeeb6b74/colorama/ansitowin32.py#L52):
```
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...
Checking closure...

```

So we basically have a name collision. In order to avoid that I've renamed the `StreamWrapper.closed` property to `.is_closed`. I'm happy to name it something else, or turn it back into a method instead of a property.