### PR TITLE
Adding goto() and size() functions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,8 +154,6 @@ ANSI codes to reposition the cursor and get the size of the terminal window are
 supported.
 
     from colorama import init, goto, size
-
-    # use Colorama to make Termcolor work on Windows too
     init()
 
     goto(0, 0)  # move cursor to top-left corner
@@ -165,6 +163,13 @@ supported.
 
 See ``demos/demo06.py`` for an example of how to generate them with raw ANSI
 codes.
+
+The screen can be cleared of all text and the cursor reposition to 0, 0:
+
+    from colorama import init, clear
+    init()
+
+    clear()
 
 
 Init Keyword Args

--- a/README.rst
+++ b/README.rst
@@ -150,8 +150,21 @@ perform this reset automatically on program exit.
 Cursor Positioning
 ------------------
 
-ANSI codes to reposition the cursor are supported. See ``demos/demo06.py`` for
-an example of how to generate them.
+ANSI codes to reposition the cursor and get the size of the terminal window are
+supported.
+
+    from colorama import init, goto, size
+
+    # use Colorama to make Termcolor work on Windows too
+    init()
+
+    goto(0, 0)  # move cursor to top-left corner
+    goto(10, 0) # move cursor to x, y position of 10, 0
+    width, height = size() # get size of terminal window
+
+
+See ``demos/demo06.py`` for an example of how to generate them with raw ANSI
+codes.
 
 
 Init Keyword Args

--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 from .initialise import init, deinit, reinit, colorama_text
-from .ansi import Fore, Back, Style, Cursor, goto, size
+from .ansi import Fore, Back, Style, Cursor, goto, size, clear
 from .ansitowin32 import AnsiToWin32
 
 __version__ = '0.4.1'

--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 from .initialise import init, deinit, reinit, colorama_text
-from .ansi import Fore, Back, Style, Cursor, goto, size, clear
+from .ansi import Fore, Back, Style, Cursor, goto, size, clear, title
 from .ansitowin32 import AnsiToWin32
 
 __version__ = '0.4.1'

--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 from .initialise import init, deinit, reinit, colorama_text
-from .ansi import Fore, Back, Style, Cursor
+from .ansi import Fore, Back, Style, Cursor, goto, size
 from .ansitowin32 import AnsiToWin32
 
 __version__ = '0.4.1'

--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -109,37 +109,21 @@ def goto(x, y):
     """Repositions the cursor to the x, y coordinates in the terminal window.
 
     (0, 0) is the top-left corner coordinate."""
-    sys.stdout.write('\x1b[%d;%dH' % (y - 1, x - 1))
+    x = 0 if x < 0 else x
+    y = 0 if y < 0 else y
+    sys.stdout.write('\x1b[%d;%dH' % (y + 1, x + 1))
 
 
 def size():
-    """Returns the size of the terminal as a tuple of two ints (width, height).
-
-    Raises an Exception when called while not in a terminal window.
-    """
-    if sys.platform in ('linux', 'darwin'):
-        return os.get_terminal_size(0)
-    elif sys.platform == 'win32':
-        # From http://code.activestate.com/recipes/440694-determine-size-of-console-window-on-windows/
-        import ctypes
-        h = ctypes.windll.kernel32.GetStdHandle(-12)
-        csbi = ctypes.create_string_buffer(22)
-        res = ctypes.windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
-
-        if res:
-            import struct
-            (bufx, bufy, curx, cury, wattr,
-             left, top, right, bottom, maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
-            return right - left + 1, bottom - top + 1
-        else:
-            raise Exception('Unable to determine terminal size. This happens in non-terminal environments, such as IDLE.')
-    else:
-        raise Exception('size() is not supported on this platform or operating system.')
+    """Returns the size of the terminal as a named tuple of two ints: (columns, lines)"""
+    return os.get_terminal_size()
 
 
-def clear():
-    """Clears the screen."""
-    if sys.platform == 'win32':
-        os.system('cls')
-    else:
-        os.system('clear')
+def clear(mode=2):
+    """Clears the terminal and positions the cursor at the top-left corner."""
+    sys.stdout.write(CSI + str(mode) + 'J')
+
+
+def title(text):
+    """Sets the title of the terminal window to text."""
+    sys.stdout.write(OSC + '2;' + text + BEL)

--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -106,6 +106,9 @@ Cursor = AnsiCursor()
 
 
 def goto(x, y):
+    """Repositions the cursor to the x, y coordinates in the terminal window.
+
+    (0, 0) is the top-left corner coordinate."""
     sys.stdout.write('\x1b[%d;%dH' % (y - 1, x - 1))
 
 

--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -135,3 +135,11 @@ def size():
             raise Exception('Unable to determine terminal size. This happens in non-terminal environments, such as IDLE.')
     else:
         raise Exception('size() is not supported on this platform or operating system.')
+
+
+def clear():
+    """Clears the screen."""
+    if sys.platform == 'win32':
+        os.system('cls')
+    else:
+        os.system('clear')


### PR DESCRIPTION
The goto() function makes it easy to reposition the cursor using 0-based coordinates as x, y (instead of the confusing y, x that curses uses). The size() function determines the size of the terminal window if possible (works on Windows, macOS, and Linux).

I think these are small additions to colorama that, while not color-specific, are likely to be used by folks using colorama as a cross-platform curses module.