### PR TITLE
[FIX] Fix example with ANSI sequence

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ constant shorthand for ANSI escape sequences:
 .. code-block:: python
 
     print('\033[31m' + 'some red text')
-    print('\033[30m') # and reset to default color
+    print('\033[39m') # and reset to default color
 
 ...or, Colorama can be used happily in conjunction with existing ANSI libraries
 such as Termcolor:


### PR DESCRIPTION
`\033[30m` is the sequence for black and I was pretty worried because I assumed it would reset but my text just disappeared (I use white text on black bg so black text disappears)

`\033[39m` is the code for reset that should be used here.