### PR TITLE
Add support for Python 3.7 and 3.8, drop EOL 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - "3.7"
   - "3.6"
   - "3.5"
-  - "3.4"
   - "pypy"
 install:
   - "pip install mock"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 cache: pip
 python:
   - "2.7"
-  - "3.8-dev"
+  - "3.8"
   - "3.7"
   - "3.6"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.5"
   - "3.4"
   - "pypy"
-sudo: false # Use container-based infrastructure
 install:
   - "pip install mock"
 script: "python -m unittest discover -p *_test.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 cache: pip
 python:
   - "2.7"
+  - "3.8-dev"
   - "3.7"
   - "3.6"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 cache: pip
 python:
   - "2.7"
+  - "3.7"
   - "3.6"
   - "3.5"
   - "3.4"

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Copyright Jonathan Hartley 2013. BSD 3-Clause license; see LICENSE file.
 Dependencies
 ============
 
-None, other than Python. Tested on Python 2.7, 3.4, 3.5 and 3.6.
+None, other than Python. Tested on Python 2.7 and 3.4+.
 
 Usage
 =====

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Copyright Jonathan Hartley 2013. BSD 3-Clause license; see LICENSE file.
 Dependencies
 ============
 
-None, other than Python. Tested on Python 2.7 and 3.4+.
+None, other than Python. Tested on Python 2.7 and 3.5+.
 
 Usage
 =====

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Copyright Jonathan Hartley 2013. BSD 3-Clause license; see LICENSE file.
 Dependencies
 ============
 
-None, other than Python. Tested on Python 2.7 and 3.5+.
+None, other than Python. Tested on Python 2.7, 3.5, 3.6, 3.7 and 3.8.
 
 Usage
 =====

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Terminals',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     url='https://github.com/tartley/colorama',
     license='BSD',
     packages=[NAME],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     # see classifiers https://pypi.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -53,7 +53,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Terminals',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy
+envlist = py27, py35, py36, py37, pypy
 
 [testenv]
 deps = mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, pypy
+envlist = py27, py35, py36, py37, py38, pypy
 
 [testenv]
 deps = mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy
+envlist = py27, py34, py35, py36, py37, pypy
 
 [testenv]
 deps = mock


### PR DESCRIPTION
Also test on Python 3.8 beta, due out in October.

* https://www.python.org/dev/peps/pep-0569/