### PR TITLE
use getattr instead of try / catch

### DIFF
--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -45,12 +45,8 @@ class StreamWrapper(object):
         if 'PYCHARM_HOSTED' in os.environ:
             if stream is not None and (stream is sys.__stdout__ or stream is sys.__stderr__):
                 return True
-        try:
-            stream_isatty = stream.isatty
-        except AttributeError:
-            return False
-        else:
-            return stream_isatty()
+        stream_isatty = getattr(stream, 'isatty', False)
+        return stream_isatty()
 
     @property
     def closed(self):


### PR DESCRIPTION
use getattr instead of try / catching the isatty attribute of stream.
This avoids the overhead of capturing and sending the traceback.
also results in cleaner code.