### PR TITLE
Guard against multiple calls to init().

### DIFF
--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -5,9 +5,10 @@ import sys
 
 from .ansitowin32 import AnsiToWin32
 
+UNSET = object()
 
-orig_stdout = None
-orig_stderr = None
+orig_stdout = UNSET
+orig_stderr = UNSET
 
 wrapped_stdout = None
 wrapped_stderr = None
@@ -28,8 +29,13 @@ def init(autoreset=False, convert=None, strip=None, wrap=True):
     global wrapped_stdout, wrapped_stderr
     global orig_stdout, orig_stderr
 
-    orig_stdout = sys.stdout
-    orig_stderr = sys.stderr
+    # Prevent multiple calls from losing the original stdout
+    if (
+        orig_stdout is UNSET and
+        orig_stderr is UNSET
+    ):
+        orig_stdout = sys.stdout
+        orig_stderr = sys.stderr
 
     if sys.stdout is None:
         wrapped_stdout = None
@@ -49,10 +55,13 @@ def init(autoreset=False, convert=None, strip=None, wrap=True):
 
 
 def deinit():
-    if orig_stdout is not None:
+    global orig_stdout, orig_stderr
+    if orig_stdout is not UNSET:
         sys.stdout = orig_stdout
-    if orig_stderr is not None:
+        orig_stdout == UNSET
+    if orig_stderr is not UNSET:
         sys.stderr = orig_stderr
+        orig_stderr == UNSET
 
 
 @contextlib.contextmanager
@@ -78,3 +87,4 @@ def wrap_stream(stream, convert, strip, autoreset, wrap):
         if wrapper.should_wrap():
             stream = wrapper.stream
     return stream
+

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -6,12 +6,11 @@ from unittest import TestCase, main
 from mock import patch
 
 from ..ansitowin32 import StreamWrapper
-from ..initialise import init
+from ..initialise import deinit, init
 from .utils import osname, redirected_output, replace_by
 
 orig_stdout = sys.stdout
 orig_stderr = sys.stderr
-
 
 class InitTest(TestCase):
 
@@ -75,13 +74,16 @@ class InitTest(TestCase):
     def testInitWrapOffIncompatibleWithAutoresetOn(self):
         self.assertRaises(ValueError, lambda: init(autoreset=True, wrap=False))
 
-    @patch('colorama.ansitowin32.winterm', None)
     @patch('colorama.ansitowin32.winapi_test', lambda *_: True)
-    def testInitOnlyWrapsOnce(self):
-        with osname("nt"):
-            init()
+    def testInitTwiceCanUndoneWithDeinitOnce(self):
+        with osname('nt'):
+            self.assertNotWrapped()
             init()
             self.assertWrapped()
+            init()
+            self.assertWrapped()
+            deinit()
+            self.assertNotWrapped()
 
     @patch('colorama.win32.SetConsoleTextAttribute')
     @patch('colorama.initialise.AnsiToWin32')


### PR DESCRIPTION
BEWARE, I haven't tested this on Windows (because I
don't have a Windows box.) It should definitely get
tested there before we merge.

This should no longer lose the original stdout/stderr,
so that we can restore them with a single call to deinit(),
while still preserving the behavior that multiple calls
to init() can override the passed values for autoreset,
convert, strip, wrap.

This fix is not intended to reset output to default
foreground/background colors after the call to
'deinit()' -  that was never intended behavior.