### PR TITLE
Added arm64 jobs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: python
 cache: pip
-python:
-  - "2.7"
-  - "3.8"
-  - "3.7"
-  - "3.6"
-  - "3.5"
-  - "pypy"
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.8
+    - arch: arm64
+      python: 3.7
+    - arch: amd64
+      python: 3.7
+    - python: 3.6
+    - python: 3.5
+    - python: pypy
 install:
   - "pip install mock"
 script: "python -m unittest discover -p *_test.py"

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -1,7 +1,7 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 import os
 import sys
-from unittest import TestCase, main
+from unittest import TestCase, main, skipUnless
 
 from mock import patch
 
@@ -15,6 +15,7 @@ orig_stderr = sys.stderr
 
 class InitTest(TestCase):
 
+    @skipUnless(sys.stdout.isatty(), "sys.stdout is not a tty")
     def setUp(self):
         # sanity check
         self.assertNotWrapped()


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 jobs in Travis-CI for python v3.7.

As per the discussion https://github.com/tartley/colorama/issues/248
