### PR TITLE
Use built-in unittest.mock when available

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -313,7 +313,7 @@ Help and fixes welcome!
 
 Running tests requires:
 
-- Michael Foord's ``mock`` module to be installed.
+- Michael Foord's ``mock`` module to be installed on Python < 3.3.
 - Tests are written using 2010-era updates to ``unittest``
 
 To run tests::

--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -2,7 +2,10 @@
 from io import StringIO
 from unittest import TestCase, main
 
-from mock import MagicMock, Mock, patch
+try:
+    from unittest.mock import MagicMock, Mock, patch
+except ImportError:
+    from mock import MagicMock, Mock, patch
 
 from ..ansitowin32 import AnsiToWin32, StreamWrapper
 from .utils import osname

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -3,7 +3,10 @@ import os
 import sys
 from unittest import TestCase, main, skipUnless
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from ..ansitowin32 import StreamWrapper
 from ..initialise import init

--- a/colorama/tests/utils.py
+++ b/colorama/tests/utils.py
@@ -4,7 +4,10 @@ from io import StringIO
 import sys
 import os
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 class StreamTTY(StringIO):
     def isatty(self):

--- a/colorama/tests/winterm_test.py
+++ b/colorama/tests/winterm_test.py
@@ -2,7 +2,10 @@
 import sys
 from unittest import TestCase, main, skipUnless
 
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from ..winterm import WinColor, WinStyle, WinTerm
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-mock>=1.0.1
+mock>=1.0.1;python_version<"3.3"
 twine>=3.1.1
 -e .

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 envlist = py27, py35, py36, py37, py38, pypy
 
 [testenv]
-deps = mock
+deps = py27,pypy: mock
 commands = python -m unittest discover -p *_test.py


### PR DESCRIPTION
Python has a built-in mocking support since 3.3.  Use the built-in
module to avoid the dependency on external mock whenever possible,
and fall back to it on older versions of Python.