### PR TITLE
Script to test releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,12 @@
 *.egg-info
 .coverage
 .tox/
-MANIFEST
-dist
-tags
+/MANIFEST
+/build/
+/dist/
+/sandbox/
+/tags
 virtualenv
-build
 
 # PyCharm
 .idea

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ clean: ## Remove build artifacts, .pyc files, virtualenv
 
 $(virtualenv):
 	$(syspython) -m venv --clear $(virtualenv)
+	$(pip) install --upgrade pip
 
 venv: $(virtualenv) ## Create or clear a virtualenv
 .PHONY: venv
@@ -58,7 +59,7 @@ test-release: build
 	./test-release
 .PHONY: test-release
 
-upload: ## Upload our sdist and wheel
+release: ## Upload our sdist and wheel
 	$(twine) upload dist/colorama-$(version)-*
 .PHONY: release
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 # with Cygwin binaries at the start of the PATH.
 
 NAME=colorama
-SHELL=/bin/bash
 
 help: ## Display help for documented make targets.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # with Cygwin binaries at the start of the PATH.
 
 NAME=colorama
+SHELL=/bin/bash
 
 help: ## Display help for documented make targets.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -18,6 +19,7 @@ pip=$(virtualenv)/bin/pip
 syspython=python3.8
 python=$(virtualenv)/bin/python
 twine=$(virtualenv)/bin/twine
+version=$(shell $(python) setup.py --version)
 
 clean: ## Remove build artifacts, .pyc files, virtualenv
 	-rm -rf build dist MANIFEST colorama.egg-info $(virtualenv)
@@ -48,11 +50,16 @@ test: ## Run tests
 
 # build packages
 
-build: clean ## Build an sdist and wheel
+build: ## Build an sdist and wheel
+	$(python) -m pip install --upgrade setuptools wheel
 	$(python) setup.py sdist bdist_wheel
 .PHONY: sdist
 
+test-release: build
+	./test-release
+.PHONY: test-release
+
 upload: ## Upload our sdist and wheel
-	$(twine) upload dist/*
+	$(twine) upload dist/colorama-$(version)-*
 .PHONY: release
 

--- a/README.rst
+++ b/README.rst
@@ -311,14 +311,42 @@ Help and fixes welcome!
 
 Tested on CPython 2.7, 3.5, 3.6, 3.7 and 3.8.
 
-No requirements. Development requirements are captured in requirements-dev.txt.
+No requirements other than the standard library.
+Development requirements are captured in requirements-dev.txt.
 
-Tests are written using standard library ``unittest``. To run them, see
-Makefile target 'test', along with a few other handy commands.
+To create and populate a virtual environment::
+
+    ./bootstrap.ps1 # Windows
+    make bootstrap # Linux
+
+To run tests::
+
+   ./test.ps1 # Windows
+   make test # Linux
 
 If you use nose to run the tests, you must pass the ``-s`` flag; otherwise,
 ``nosetests`` applies its own proxy to ``stdout``, which confuses the unit
 tests.
+
+To build a local wheel file::
+
+    ./build.ps1 # Windows
+    make build # Linux
+
+To test the wheel, (upload to test PyPI, then 'pip install' & use it)::
+
+    ./test-release.ps1 # Windows
+    make test-release # Linux
+
+To upload the wheel to PyPI::
+
+    ./release.ps1 # Windows
+    make release # Linux
+
+To clean all generated files, builds, virtualenv::
+
+    ./clean.ps1 # Windows
+    make clean # Linux
 
 
 Professional support

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,9 @@
+$syspython="python3.8.exe"
+$ve="$HOME\.virtualenvs\colorama"
+$bin="$ve\Scripts"
+
+echo "Create $syspython virtualenv $ve"
+& $syspython -m venv --clear "$ve"
+& $bin\python.exe -m pip install --upgrade pip
+& $bin\python.exe -m pip install -r requirements.txt -r requirements-dev.txt
+

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,6 @@
+$ve="$HOME\.virtualenvs\colorama"
+$bin="$ve\Scripts"
+
+& $bin\python.exe -m pip install --upgrade setuptools wheel
+& $bin\python.exe setup.py sdist bdist_wheel
+

--- a/clean.ps1
+++ b/clean.ps1
@@ -1,0 +1,6 @@
+$syspython="python3.8.exe"
+$ve="$HOME\.virtualenvs\colorama"
+
+remove-item -r -fo * -I build,dist,MANIFEST,colorama.egg-info,$ve,sandbox
+& $syspython -Bc "import pathlib, shutil; [shutil.rmtree(p) for p in pathlib.Path('.').rglob('__pycache__')]"
+

--- a/release.ps1
+++ b/release.ps1
@@ -1,0 +1,7 @@
+$ve="$HOME\.virtualenvs\colorama"
+$bin="$ve\Scripts"
+$version="$(& $bin\python.exe setup.py --version)"
+
+# Upload to PyPI.
+& $bin\twine.exe upload dist\colorama-$version-*
+

--- a/test-release
+++ b/test-release
@@ -18,7 +18,7 @@ bin="$HOME/.virtualenvs/colorama/bin"
 version=$($bin/python setup.py --version)
 sandbox=test-release-playground
 
-# Upload to the test pypi.
+# Upload to the test PyPI.
 $bin/twine upload --repository testpypi dist/colorama-$version-* \
     || echo "  > Expect a 400 if package was already uploaded."
 
@@ -27,13 +27,13 @@ mkdir -p $sandbox
 (
     cd $sandbox
 
-    # Create a new virtualenv
+    # Create a temporary disposable virtualenv.
     $syspython -m venv --clear venv
 
-    # Install the package we just uploaded
+    # Install the package we just uploaded.
     venv/bin/python -m pip --quiet install --index-url https://test.pypi.org/simple colorama==$version
 
-    # Test the package can be imported
+    # Import and use Colorama from the temp virtualenv.
     venv/bin/python -c "import colorama; colorama.init(); print(colorama.Fore.GREEN + \"OK: Colorama\", colorama.__version__, \"from test pypi install.\")"
 )
 

--- a/test-release
+++ b/test-release
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 
 # Test the currently built release of Colorama from the dist/ dir.
 # Run this before making a release.

--- a/test-release
+++ b/test-release
@@ -1,0 +1,42 @@
+#/usr/bin/env bash
+
+# Test the currently built release of Colorama from the dist/ dir.
+# Run this before making a release.
+#
+# This should be run on Windows, because Colorama is mostly a no-op elsewhere.
+# Hmmm, this script should probably be a .bat file then? Nah, WSL FTW.
+#
+# Uploads package from the dist/ directory to the *test* PyPI.
+# Create a fresh virtualenvironment and install colorama from test PyPI.
+# Import Colorama and make trivial use of it.
+
+# Exit on error
+set -eu -o pipefail
+
+syspython=python3.8
+bin="$HOME/.virtualenvs/colorama/bin"
+version=$($bin/python setup.py --version)
+sandbox=test-release-playground
+
+# Upload to the test pypi.
+$bin/twine upload --repository testpypi dist/colorama-$version-* \
+    || echo "  > Expect a 400 if package was already uploaded."
+
+# cd elsewhere so we cannot import from local source.
+mkdir -p $sandbox
+(
+    cd $sandbox
+
+    # Create a new virtualenv
+    $syspython -m venv --clear venv
+
+    # Install the package we just uploaded
+    venv/bin/python -m pip --quiet install --index-url https://test.pypi.org/simple colorama==$version
+
+    # Test the package can be imported
+    venv/bin/python -c "import colorama; colorama.init(); print(colorama.Fore.GREEN + \"OK: Colorama\", colorama.__version__, \"from test pypi install.\")"
+)
+
+# Tidy up
+rm -rf $sandbox
+

--- a/test-release.ps1
+++ b/test-release.ps1
@@ -1,0 +1,29 @@
+$syspython="python3.8.exe"
+$ve="$HOME\.virtualenvs\colorama"
+$bin="$ve\Scripts"
+$version="$(& $bin\python.exe setup.py --version)"
+
+# Upload to the test PyPI.
+& $bin\twine.exe upload --repository testpypi dist\colorama-$version-*
+if(!$?) {
+    write-host "  > Expect a 400 if package was already uploaded"
+}
+
+# cd elsewhere so we cannot import from local source.
+mkdir -force sandbox | out-null
+cd sandbox
+
+# Create a temporary disposable virtualenv.
+& $syspython -m venv --clear venv
+
+# Install the package we just uploaded.
+venv\Scripts\python -m pip --quiet install --index-url https://test.pypi.org/simple colorama==$version
+# Import and use colorama from the temp virtualenv.
+venv\Scripts\python.exe -c @"
+import colorama;
+colorama.init();
+print(colorama.Fore.GREEN + ""OK Colorama "" + colorama.__version__ + "" from test pypi install."")
+"@
+
+cd ..
+

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,5 @@
+$ve="$HOME\.virtualenvs\colorama"
+$bin="$ve\Scripts"
+
+& $bin\python.exe -m unittest discover -p *_test.py
+


### PR DESCRIPTION
Add a new 'test-release' script and makefile target

Running the script sends the already built package to
test pypi, then uses pip to download and install it from
there, and does a minimal invocation of the installed
package. If the package has not been built correctly,
this might detect some errors before we send it to
the real pypi.
