### PR TITLE
Make ansitowin32 tests pass on all OS

### DIFF
--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -170,13 +170,19 @@ class AnsiToWin32Test(TestCase):
     def test_wrap_shouldnt_raise_on_closed_orig_stdout(self):
         stream = StringIO()
         stream.close()
-        converter = AnsiToWin32(stream)
-        self.assertFalse(converter.strip)
+        with \
+            patch("colorama.ansitowin32.os.name", "nt"), \
+            patch("colorama.ansitowin32.winapi_test", lambda: True):
+                converter = AnsiToWin32(stream)
+        self.assertTrue(converter.strip)
         self.assertFalse(converter.convert)
 
     def test_wrap_shouldnt_raise_on_missing_closed_attr(self):
-        converter = AnsiToWin32(object())
-        self.assertFalse(converter.strip)
+        with \
+            patch("colorama.ansitowin32.os.name", "nt"), \
+            patch("colorama.ansitowin32.winapi_test", lambda: True):
+                converter = AnsiToWin32(object())
+        self.assertTrue(converter.strip)
         self.assertFalse(converter.convert)
 
     def testExtractParams(self):


### PR DESCRIPTION
These were failing for me when run on Windows.
But passed on Linux.

It wasn't immediately clear to me whether it was the failing
test that was wrong, or the implementation. But I recall this
section of code undergoing much-discussed changes a
year or more ago, so I'm loathe to mess with it without
understanding the context. Presumably if the code was
wrong, users would be complaining.

So I fixed the tests, and now they should pass everywhere
(I tried on Linux and Windows.)