### PR TITLE
Remove unused test imports and utils

### DIFF
--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -1,5 +1,4 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
-import os
 import sys
 from unittest import TestCase, main, skipUnless
 
@@ -10,7 +9,7 @@ except ImportError:
 
 from ..ansitowin32 import StreamWrapper
 from ..initialise import init
-from .utils import osname, redirected_output, replace_by
+from .utils import osname, replace_by
 
 orig_stdout = sys.stdout
 orig_stderr = sys.stderr

--- a/colorama/tests/utils.py
+++ b/colorama/tests/utils.py
@@ -4,10 +4,6 @@ from io import StringIO
 import sys
 import os
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
 
 class StreamTTY(StringIO):
     def isatty(self):
@@ -23,14 +19,6 @@ def osname(name):
     os.name = name
     yield
     os.name = orig
-
-@contextmanager
-def redirected_output():
-    orig = sys.stdout
-    sys.stdout = Mock()
-    sys.stdout.isatty = lambda: False
-    yield
-    sys.stdout = orig
 
 @contextmanager
 def replace_by(stream):


### PR DESCRIPTION
Removing unused imports exposed redirected_output() as an unused
function. It too has been removed.