### PR TITLE
Use ASCII decoding explicitly in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 from __future__ import with_statement
 
+from io import open
 import os
 import re
 try:
@@ -14,8 +15,9 @@ except ImportError:
 NAME = 'colorama'
 
 
-def read_file(path):
-    with open(os.path.join(os.path.dirname(__file__), path)) as fp:
+def read_file(path, encoding='ascii'):
+    with open(os.path.join(os.path.dirname(__file__), path),
+              encoding=encoding) as fp:
         return fp.read()
 
 def _get_version_match(content):


### PR DESCRIPTION
Prevents future regression of #291 following 688f6cc