### PR TITLE
Added check to ensure init() will only have any effect in Windows.

### DIFF
--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -25,6 +25,12 @@ def init(autoreset=False, convert=None, strip=None, wrap=True):
     if not wrap and any([autoreset, convert, strip]):
         raise ValueError('wrap=False conflicts with any other arg=True')
 
+    # This function is only intended to have any effect when it's run on Windows.
+    # To ensure that unexpected side effects do not occur on any other platform,
+    # we return immediately if not running on Windows.
+    if sys.platform != 'win32':
+        return
+
     global wrapped_stdout, wrapped_stderr
     global orig_stdout, orig_stderr
 


### PR DESCRIPTION
Much like #304, I am also experiencing issues because of the not-quite-true nature of that line from the docs that carltongibson quoted.

> On other platforms, calling init() has no effect

This is untrue when running in Linux within a Docker container, because even if you don't pass `strip=True` to `init()`, it'll still act like you did because in Docker, `sys.stderr` isn't a tty. It's a file descriptor that prints to a special log file which you can follow to get output that *looks* like a tty, but `isatty()` returns False. This forces `strip=True`, do to the `if strip is None` check in the `AnsiToWin32` constructor, which activates the `AnsiToWin32` wrapper even though the code isn't running on Windows. This completely breaks the colored output of all logs coming out of the Docker container.

This pull request makes it 100% certain that Colorama won't screw around with `sys.stderr` or `sys.stdout` unless the program is actually running on Windows. Libraries like StructLog already wrap their call to `colorama.init()` in such a check, so I figure that Colorama itself should be doing this.