### PR TITLE
Add support for Python 3.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ If you find Colorama useful, please |donate| to the authors. Thank you!
 Installation
 ------------
 
-Tested on CPython 2.7, 3.5, 3.6, 3.7, 3.8 and 3.9 and Pypy 2.7 and 3.6.
+Tested on CPython 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 and 3.10 and Pypy 2.7 and 3.6.
 
 No requirements other than the standard library.
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Terminals',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, pypy, pypy3
+envlist = py27, py35, py36, py37, py38, py39, py310, pypy, pypy3
 
 [testenv]
 deps = py27,pypy: mock


### PR DESCRIPTION
```console
$ tox -e py310
GLOB sdist-make: /private/tmp/colorama/setup.py
py310 create: /private/tmp/colorama/.tox/py310
py310 inst: /private/tmp/colorama/.tox/.tmp/package/1/colorama-0.4.5rc0.zip
py310 testmon: setting TESTMON_DATAFILE=/private/tmp/colorama/.tox/py310/.testmondata
py310 installed: colorama @ file:///private/tmp/colorama/.tox/.tmp/package/1/colorama-0.4.5rc0.zip
py310 run-test-pre: PYTHONHASHSEED='2568120525'
py310 run-test: commands[0] | python -m unittest discover -p '*_test.py'
.........................................sss....s
----------------------------------------------------------------------
Ran 49 tests in 0.038s

OK (skipped=4)
______________________________________________________ summary _______________________________________________________
  py310: commands succeeded
  congratulations :)
```
