### PR TITLE
Atexit fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,11 @@ Available formatting constants are::
 ``Style.RESET_ALL`` resets foreground, background, and brightness. Colorama will
 perform this reset automatically on program exit.
 
+These are fairly well supported, but not part of the standard::
+
+    Fore: LIGHTBLACK_EX, LIGHTRED_EX, LIGHTGREEN_EX, LIGHTYELLOW_EX, LIGHTBLUE_EX, LIGHTMAGENTA_EX, LIGHTCYAN_EX, LIGHTWHITE_EX
+    Back: LIGHTBLACK_EX, LIGHTRED_EX, LIGHTGREEN_EX, LIGHTYELLOW_EX, LIGHTBLUE_EX, LIGHTMAGENTA_EX, LIGHTCYAN_EX, LIGHTWHITE_EX
+
 
 Cursor Positioning
 ..................

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -57,7 +57,9 @@ class StreamWrapper(object):
         stream = self.__wrapped
         try:
             return stream.closed
-        except AttributeError:
+        # AttributeError in the case that the stream doesn't support being closed
+        # ValueError for the case that the stream has already been detached when atexit runs
+        except (AttributeError, ValueError):
             return True
 
 

--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -1,5 +1,5 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
-from io import StringIO
+from io import StringIO, TextIOWrapper
 from unittest import TestCase, main
 
 try:
@@ -40,6 +40,17 @@ class StreamWrapperTest(TestCase):
             with StreamWrapper(mockStream, mockConverter) as wrapper:
                 wrapper.write('hello')
 
+    def test_closed_shouldnt_raise_on_closed_stream(self):
+        stream = StringIO()
+        stream.close()
+        wrapper = StreamWrapper(stream, None)
+        self.assertEqual(wrapper.closed, True)
+
+    def test_closed_shouldnt_raise_on_detached_stream(self):
+        stream = TextIOWrapper(StringIO())
+        stream.detach()
+        wrapper = StreamWrapper(stream, None)
+        self.assertEqual(wrapper.closed, True)
 
 class AnsiToWin32Test(TestCase):
 


### PR DESCRIPTION
A library we use throws this annoying error when it's called in under certain conditions. It's probably doing something wrong, but I think `colorama` should be more resilient to this particular bad state. I've attached the script that demonstrates the error. I've tried to write a test for this, but the best I can to do honestly test the functionality is to spin up a new Python in a subprocess that calls `colorama`,  this seems awkward and was difficult to make portable. If it's your desire I'll do it though.

```
from __future__ import print_function

import codecs
import sys

from colorama import init

init()
sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())

print("foo", sys.stdout)
```

Before and after the fix:
![image](https://user-images.githubusercontent.com/1138504/139348605-7c6bc421-79ec-4d50-bd6a-58ca610885b7.png)

![image](https://user-images.githubusercontent.com/1138504/139348625-704cb415-5182-4cb2-ae57-1a2c505269e3.png)




Rejected test attempt:
```
    def testDetachAfterInitDoesntThrow(self):
        fd, name = tempfile.mkstemp(suffix=".py", text=True)
        sample_python = """
from __future__ import print_function

import codecs
import sys

from colorama import init

init()
sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())

print("Hello", sys.stdout)
        """
        temp_script = Path(name)
        with temp_script.open(mode="w") as f:
            f.write(sample_python)
        output = subprocess.check_output(["python", str(temp_script)], universal_newlines=True)
        print(output)
        assert "buffer" not in output
```