### PR TITLE
CI: Replace deprecated pypyX with pypy-X.Y

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy2", "pypy3", "2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-2.7", "pypy-3.8", "2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Add new helper variables to existing jobs
-          - {python-version: "pypy2", toxenv: "pypy"}
-          - {python-version: "pypy3", toxenv: "pypy3"}
+          - {python-version: "pypy-2.7", toxenv: "pypy"}
+          - {python-version: "pypy-3.8", toxenv: "pypy3"}
           - {python-version: "2.7", toxenv: "py27"}
           - {python-version: "3.5", toxenv: "py35"}
           - {python-version: "3.6", toxenv: "py36"}


### PR DESCRIPTION
`pypyX` is deprecated and is not available in newer images:
https://github.com/actions/setup-python/issues/244#issuecomment-925966022

Instead explicitly specify the version:
https://github.com/actions/setup-python#specifying-a-pypy-version
