### PR TITLE
Add methods to ``StreamWrapper`` to allow better pickling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
   * Fix some tests that were failing on some operating systems.
   * Add support for Python 3.9.
   * Add support for PyPy3.
+  * Add support for pickling with the ``dill`` module.
 0.4.4 Current release
   * Re-org of README, to put the most insteresting parts near the top.
   * Added Linux makefile targets and Windows powershell scripts to

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -37,6 +37,12 @@ class StreamWrapper(object):
     def __exit__(self, *args, **kwargs):
         return self.__wrapped.__exit__(*args, **kwargs)
 
+    def __setstate__(self, state):
+        self.__dict__ = state
+
+    def __getstate__(self):
+        return self.__dict__
+
     def write(self, text):
         self.__convertor.write(text)
 


### PR DESCRIPTION
Closes #86.

The popular python linter `pylint` has updated its pickler module from the `stdlib` `pickle` to the widely used `dill` package. However, users have run into issues with this as `colorama` apparently does not support pickling by `dill`. One user already identified this issue 6 years ago, but a fix was never submitted.

The following fixes the issue and passes all tests. We would appreciate if this could get merged as `pylint` is somewhat unable to return to `pickle` but we also don't want to stop supporting `colorama`. 

As for a test, I didn't want to add `dill` as a test dependency, but that would be the easiest way to test this I think. Just trying to pickle `StreamWrapper` with `dill` would fail without the code in this PR.