### PR TITLE
Enfoce reuse compliance

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # These are supported funding model platforms
 
 # community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: lint_python
 on: [pull_request, push]
 jobs:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Copied from https://github.com/fsfe/reuse-action#example-usage
+
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: 
+    - uses: actions/checkout@v2
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: Test
 
 on: [push, pull_request, workflow_dispatch]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 *.pyc
 *.egg-info
 .coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+..
+.. SPDX-License-Identifier: BSD-3-Clause
+
 0.4.5 In progress, unreleased
   * Create README-hacking.md, for Colorama contributors.
   * Tweak some README unicode characters that don't render correctly on PyPI.

--- a/ENTERPRISE.md
+++ b/ENTERPRISE.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 # Colorama for enterprise.
 
 *Available as part of the Tidelift Subscription.*

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 include LICENSE.txt CHANGELOG.rst
 recursive-include demos *.py *.bat *.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE.txt file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE.txt file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 # This makefile is just a cheatsheet to remind me of some commonly used
 # commands. I generally am executing these commands on Ubuntu, or on WindowsXP

--- a/README-hacking.md
+++ b/README-hacking.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 # Colorama Development
 
 Help and fixes are welcome!

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+..
+.. SPDX-License-Identifier: BSD-3-Clause
+
 .. image:: https://img.shields.io/pypi/v/colorama.svg
     :target: https://pypi.org/project/colorama/
     :alt: Latest Version

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 # Security policy
 
 To report sensitive vulnerability information, please use the [Tidelift security contact](https://tidelift.com/security). Tidelift will coordinate the fix and disclosure.

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 $syspython="python3.8.exe"
 $ve="$HOME\.virtualenvs\colorama"
 $bin="$ve\Scripts"

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 $ve="$HOME\.virtualenvs\colorama"
 $bin="$ve\Scripts"
 

--- a/clean.ps1
+++ b/clean.ps1
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 $syspython="python3.8.exe"
 $ve="$HOME\.virtualenvs\colorama"
 

--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from .initialise import init, deinit, reinit, colorama_text
 from .ansi import Fore, Back, Style, Cursor
 from .ansitowin32 import AnsiToWin32

--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 '''
 This module generates ANSI character codes to printing colors to terminals.
 See: http://en.wikipedia.org/wiki/ANSI_escape_code

--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import re
 import sys
 import os

--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import atexit
 import contextlib
 import sys

--- a/colorama/tests/__init__.py
+++ b/colorama/tests/__init__.py
@@ -1,1 +1,4 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/tests/__init__.py
+++ b/colorama/tests/__init__.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/tests/ansi_test.py
+++ b/colorama/tests/ansi_test.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/tests/ansi_test.py
+++ b/colorama/tests/ansi_test.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import sys
 from unittest import TestCase, main
 

--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from io import StringIO
 from unittest import TestCase, main
 

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import sys
 from unittest import TestCase, main, skipUnless
 

--- a/colorama/tests/isatty_test.py
+++ b/colorama/tests/isatty_test.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/tests/isatty_test.py
+++ b/colorama/tests/isatty_test.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import sys
 from unittest import TestCase, main
 

--- a/colorama/tests/utils.py
+++ b/colorama/tests/utils.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/tests/utils.py
+++ b/colorama/tests/utils.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from contextlib import contextmanager
 from io import StringIO
 import sys

--- a/colorama/tests/winterm_test.py
+++ b/colorama/tests/winterm_test.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/tests/winterm_test.py
+++ b/colorama/tests/winterm_test.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import sys
 from unittest import TestCase, main, skipUnless
 

--- a/colorama/win32.py
+++ b/colorama/win32.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/win32.py
+++ b/colorama/win32.py
@@ -1,4 +1,7 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 # from winbase.h
 STDOUT = -11

--- a/colorama/winterm.py
+++ b/colorama/winterm.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/colorama/winterm.py
+++ b/colorama/winterm.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from . import win32
 
 

--- a/demos/demo.bat
+++ b/demos/demo.bat
@@ -1,3 +1,7 @@
+REM SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+REM
+REM SPDX-License-Identifier: BSD-3-Clause
+
 :: Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 
 :: Script to demonstrate features of colorama.

--- a/demos/demo.bat
+++ b/demos/demo.bat
@@ -1,8 +1,6 @@
-REM SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
-REM
-REM SPDX-License-Identifier: BSD-3-Clause
+:: SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 
-:: Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+:: SPDX-License-Identifier: BSD-3-Clause
 
 :: Script to demonstrate features of colorama.
 

--- a/demos/demo.sh
+++ b/demos/demo.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/demos/demo.sh
+++ b/demos/demo.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
+
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Script to demonstrate features of colorama.
 

--- a/demos/demo01.py
+++ b/demos/demo01.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python
+
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 # print grid of all colors and brightnesses
 # uses stdout.write to write chars with no newline nor spaces between them

--- a/demos/demo01.py
+++ b/demos/demo01.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/demos/demo02.py
+++ b/demos/demo02.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python
+
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Simple demo of changing foreground, background and brightness.
 

--- a/demos/demo02.py
+++ b/demos/demo02.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/demos/demo03.py
+++ b/demos/demo03.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python
+
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Demonstrate the different behavior when autoreset is True and False.
 

--- a/demos/demo03.py
+++ b/demos/demo03.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/demos/demo04.py
+++ b/demos/demo04.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python
+
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 # check that stripped ANSI in redirected stderr does not affect stdout
 from __future__ import print_function

--- a/demos/demo04.py
+++ b/demos/demo04.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/demos/demo05.py
+++ b/demos/demo05.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python
+
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Demonstrate the difference between colorama initialized with wrapping on and off.
 # The point of the demonstration is to show how the ANSI wrapping on Windows can be disabled.

--- a/demos/demo05.py
+++ b/demos/demo05.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/demos/demo06.py
+++ b/demos/demo06.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/demos/demo06.py
+++ b/demos/demo06.py
@@ -1,4 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from __future__ import print_function
 import fixpath
 import colorama

--- a/demos/demo07.py
+++ b/demos/demo07.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from __future__ import print_function
 import fixpath
 import colorama

--- a/demos/demo08.py
+++ b/demos/demo08.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from __future__ import print_function
 import fixpath
 from colorama import colorama_text, Fore

--- a/demos/demo09.py
+++ b/demos/demo09.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # https://www.youtube.com/watch?v=F5a8RLY2N8M&list=PL1_riyn9sOjcKIAYzo7f8drxD-Yg9La-D&index=61
 # Generic colorama demo using command line arguments
 # By George Ogden

--- a/demos/fixpath.py
+++ b/demos/fixpath.py
@@ -1,4 +1,3 @@
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/demos/fixpath.py
+++ b/demos/fixpath.py
@@ -1,4 +1,7 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Add demo dir's parent to sys path, so that 'import colorama' always finds
 # the local source in preference to any installed version of colorama.

--- a/release.ps1
+++ b/release.ps1
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 $ve="$HOME\.virtualenvs\colorama"
 $bin="$ve\Scripts"
 $version="$(& $bin\python.exe setup.py --version)"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 mock>=1.0.1;python_version<"3.3"
 twine>=3.1.1
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # none

--- a/screenshots/ubuntu-demo.png.license
+++ b/screenshots/ubuntu-demo.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014 Jonathan Hartley
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/screenshots/windows-demo.png.license
+++ b/screenshots/windows-demo.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014 Jonathan Hartley
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 # SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
+
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import with_statement
 

--- a/test-release
+++ b/test-release
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Test the currently built release of Colorama from the dist/ dir.
 # Run this before making a release.
 #

--- a/test-release.ps1
+++ b/test-release.ps1
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 $syspython="python3.8.exe"
 $ve="$HOME\.virtualenvs\colorama"
 $bin="$ve\Scripts"

--- a/test.ps1
+++ b/test.ps1
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 $ve="$HOME\.virtualenvs\colorama"
 $bin="$ve\Scripts"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: 2013-2022 Jonathan Hartley & Arnon Yaari
+;
+; SPDX-License-Identifier: BSD-3-Clause
+
 [tox]
 envlist = py27, py35, py36, py37, py38, py39, py310, pypy, pypy3
 


### PR DESCRIPTION
The https://reuse.software specification is the standard for providing machine-readable licensing and copyright information.

I believe:
* machine-readable metadata is a good thing.
* licensing and copyright matter
* automation is a good thing.

Therefore I propose we:
1. Make colorama compliant with the https://reuse.software/ specification
2. Enfoce compliance via a github action