### PR TITLE
Add colorama.just_fix_windows_console()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,8 @@ This has the upshot of providing a simple cross-platform API for printing
 colored terminal text from Python, and has the happy side-effect that existing
 applications or libraries which use ANSI sequences to produce colored output on
 Linux or Macs can now also work on Windows, simply by calling
-``colorama.init()``.
+``colorama.just_fix_windows_console()`` (since v0.4.6) or ``colorama.init()``
+(all versions, but may have other side-effects – see below).
 
 An alternative approach is to install ``ansi.sys`` on Windows machines, which
 provides the same behaviour for all applications running in terminals. Colorama
@@ -85,29 +86,65 @@ Usage
 Initialisation
 ..............
 
-Applications should initialise Colorama using:
+If the only thing you want from Colorama is to get ANSI escapes to work on
+Windows, then run:
+
+.. code-block:: python
+
+    from colorama import just_fix_windows_console
+    just_fix_windows_console()
+
+If you're on a recent version of Windows 10 or better, and your stdout/stderr
+are pointing to a Windows console, then this will flip the magic configuration
+switch to enable Windows' built-in ANSI support.
+
+If you're on an older version of Windows, and your stdout/stderr are pointing to
+a Windows console, then this will wrap ``sys.stdout`` and/or ``sys.stderr`` in a
+magic file object that intercepts ANSI escape sequences and issues the
+appropriate Win32 calls to emulate them.
+
+In all other circumstances, it does nothing whatsoever. Basically the idea is
+that this makes Windows act like Unix with respect to ANSI escape handling.
+
+It's safe to call this function multiple times. It's safe to call this function
+on non-Windows platforms, but it won't do anything. It's safe to call this
+function when one or both of your stdout/stderr are redirected to a file – it
+won't do anything to those streams.
+
+Alternatively, you can use the older interface with more features (but also more
+potential footguns):
 
 .. code-block:: python
 
     from colorama import init
     init()
 
-On Windows, calling ``init()`` will filter ANSI escape sequences out of any
-text sent to ``stdout`` or ``stderr``, and replace them with equivalent Win32
-calls.
+This does the same thing as ``just_fix_windows_console``, except for the
+following differences:
 
-On other platforms, calling ``init()`` has no effect (unless you request other
-optional functionality, see "Init Keyword Args" below; or if output
-is redirected). By design, this permits applications to call ``init()``
-unconditionally on all platforms, after which ANSI output should just work.
+- It's not safe to call ``init`` multiple times; you can end up with multiple
+  layers of wrapping and broken ANSI support.
 
-On all platforms, if output is redirected, ANSI escape sequences are completely
-stripped out.
+- Colorama will apply a heuristic to guess whether stdout/stderr support ANSI,
+  and if it thinks they don't, then it will wrap ``sys.stdout`` and
+  ``sys.stderr`` in a magic file object that strips out ANSI escape sequences
+  before printing them. This happens on all platforms, and can be convenient if
+  you want to write your code to emit ANSI escape sequences unconditionally, and
+  let Colorama decide whether they should actually be output. But note that
+  Colorama's heuristic is not particularly clever.
+
+- ``init`` also accepts explicit keyword args to enable/disable various
+  functionality – see below.
 
 To stop using Colorama before your program exits, simply call ``deinit()``.
 This will restore ``stdout`` and ``stderr`` to their original values, so that
 Colorama is disabled. To resume using Colorama again, call ``reinit()``; it is
 cheaper than calling ``init()`` again (but does the same thing).
+
+Most users should depend on ``colorama >= 0.4.6``, and use
+``just_fix_windows_console``. The old ``init`` interface will be supported
+indefinitely for backwards compatibility, but we don't plan to fix any issues
+with it, also for backwards compatibility.
 
 
 Colored Output
@@ -145,11 +182,11 @@ those ANSI sequences to also work on Windows:
 
 .. code-block:: python
 
-    from colorama import init
+    from colorama import just_fix_windows_console
     from termcolor import colored
 
     # use Colorama to make Termcolor work on Windows too
-    init()
+    just_fix_windows_console()
 
     # then use Termcolor for all colored text output
     print(colored('Hello, World!', 'green', 'on_red'))

--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,5 +1,5 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
-from .initialise import init, deinit, reinit, colorama_text
+from .initialise import init, deinit, reinit, colorama_text, just_fix_windows_console
 from .ansi import Fore, Back, Style, Cursor
 from .ansitowin32 import AnsiToWin32
 

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -271,3 +271,7 @@ class AnsiToWin32(object):
                     if params[0] in '02':
                         winterm.set_title(params[1])
         return text
+
+
+    def flush(self):
+        self.wrapped.flush()

--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -21,8 +21,12 @@ def _wipe_internal_state_for_tests():
     global fixed_windows_console
     fixed_windows_console = False
 
-    # no-op if it wasn't registered
-    atexit.unregister(reset_all)
+    try:
+        # no-op if it wasn't registered
+        atexit.unregister(reset_all)
+    except AttributeError:
+        # python 2: no atexit.unregister. Oh well, we did our best.
+        pass
 
 
 def reset_all():

--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -6,15 +6,24 @@ import sys
 from .ansitowin32 import AnsiToWin32
 
 
-orig_stdout = None
-orig_stderr = None
+def _wipe_internal_state_for_tests():
+    global orig_stdout, orig_stderr
+    orig_stdout = None
+    orig_stderr = None
 
-wrapped_stdout = None
-wrapped_stderr = None
+    global wrapped_stdout, wrapped_stderr
+    wrapped_stdout = None
+    wrapped_stderr = None
 
-atexit_done = False
+    global atexit_done
+    atexit_done = False
 
-fixed_windows_console = False
+    global fixed_windows_console
+    fixed_windows_console = False
+
+    # no-op if it wasn't registered
+    atexit.unregister(reset_all)
+
 
 def reset_all():
     if AnsiToWin32 is not None:    # Issue #74: objects might become None at exit
@@ -102,3 +111,7 @@ def wrap_stream(stream, convert, strip, autoreset, wrap):
         if wrapper.should_wrap():
             stream = wrapper.stream
     return stream
+
+
+# Use this for initial setup as well, to reduce code duplication
+_wipe_internal_state_for_tests()

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -8,7 +8,7 @@ except ImportError:
     from mock import patch
 
 from ..ansitowin32 import StreamWrapper
-from ..initialise import init
+from ..initialise import init, just_fix_windows_console, _wipe_internal_state_for_tests
 from .utils import osname, replace_by
 
 orig_stdout = sys.stdout
@@ -23,6 +23,7 @@ class InitTest(TestCase):
         self.assertNotWrapped()
 
     def tearDown(self):
+        _wipe_internal_state_for_tests()
         sys.stdout = orig_stdout
         sys.stderr = orig_stderr
 

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -78,14 +78,6 @@ class InitTest(TestCase):
     def testInitWrapOffIncompatibleWithAutoresetOn(self):
         self.assertRaises(ValueError, lambda: init(autoreset=True, wrap=False))
 
-    @patch('colorama.ansitowin32.winterm', None)
-    @patch('colorama.ansitowin32.winapi_test', lambda *_: True)
-    def testInitOnlyWrapsOnce(self):
-        with osname("nt"):
-            init()
-            init()
-            self.assertWrapped()
-
     @patch('colorama.win32.SetConsoleTextAttribute')
     @patch('colorama.initialise.AnsiToWin32')
     def testAutoResetPassedOn(self, mockATW32, _):

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -40,6 +40,7 @@ class InitTest(TestCase):
 
     @patch('colorama.initialise.reset_all')
     @patch('colorama.ansitowin32.winapi_test', lambda *_: True)
+    @patch('colorama.ansitowin32.enable_vt_processing', lambda *_: False)
     def testInitWrapsOnWindows(self, _):
         with osname("nt"):
             init()

--- a/colorama/winterm.py
+++ b/colorama/winterm.py
@@ -190,5 +190,6 @@ def enable_vt_processing(fd):
         mode = win32.GetConsoleMode(handle)
         if mode & win32.ENABLE_VIRTUAL_TERMINAL_PROCESSING:
             return True
-    except OSError:
+    # Can get TypeError in testsuite where 'fd' is a Mock()
+    except (OSError, TypeError):
         return False

--- a/demos/demo01.py
+++ b/demos/demo01.py
@@ -10,9 +10,9 @@ import sys
 # Add parent dir to sys path, so the following 'import colorama' always finds
 # the local source in preference to any installed version of colorama.
 import fixpath
-from colorama import init, Fore, Back, Style
+from colorama import just_fix_windows_console, Fore, Back, Style
 
-init()
+just_fix_windows_console()
 
 # Fore, Back and Style are convenience classes for the constant ANSI strings that set
 #     the foreground, background and style. The don't have any magic of their own.

--- a/demos/demo02.py
+++ b/demos/demo02.py
@@ -5,9 +5,9 @@
 
 from __future__ import print_function
 import fixpath
-from colorama import init, Fore, Back, Style
+from colorama import just_fix_windows_console, Fore, Back, Style
 
-init()
+just_fix_windows_console()
 
 print(Fore.GREEN + 'green, '
     + Fore.RED + 'red, '

--- a/demos/demo06.py
+++ b/demos/demo06.py
@@ -24,7 +24,7 @@ CHARS = ' ' + printable.strip()
 PASSES = 1000
 
 def main():
-    colorama.init()
+    colorama.just_fix_windows_console()
     pos = lambda y, x: Cursor.POS(x, y)
     # draw a white border.
     print(Back.WHITE, end='')

--- a/demos/demo07.py
+++ b/demos/demo07.py
@@ -16,7 +16,7 @@ def main():
     aba
     3a4
     """
-    colorama.init()
+    colorama.just_fix_windows_console()
     print("aaa")
     print("aaa")
     print("aaa")


### PR DESCRIPTION
As discussed in https://github.com/tartley/colorama/pull/139

Re: the bugs you collected:

> * [Guard against multiple calls to init(). #236](https://github.com/tartley/colorama/pull/236)  Guard against multiple calls to init()
> * [Prevent user from wrapping already wrapped streams #201](https://github.com/tartley/colorama/pull/201) Prevent user from wrapping already-wrapped streams

`just_fix_windows_console()` is a no-op if run repeatedly, or if run after someone else has called `init`.

> * [Support possibility to wrap either stdout or stderr #257](https://github.com/tartley/colorama/pull/257) Support possibility to wrap either stdout or stderr (for binary stdout)

`just_fix_windows_console` only touches streams that are pointing to a Windows console. So I guess in theory it would still interfere with your random binary if you try dumping it on your terminal, but (a) no-one expects that to do anything useful, (b) it interprets the random binary the same way a Unix console would, and people seem to live with that. So I'm not worried about it.

I've tested this manually (running `demos/demo01.py`) on Linux/Win7/Win10.

The big remaining issue is that I'm not sure how to test this, because it touches global state, and `init` also touches global state, and I'm not sure how to make all the tests run in a single process.