### PR TITLE
Add UNDERLINE and NEGATIVE to ansi.py

### DIFF
--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -28,7 +28,7 @@ class AnsiCodes(object):
         # Upon instantiation we define instance attributes, which are the same
         # as the class attributes but wrapped with the ANSI escape sequence
         for name in dir(self):
-            if not name.startswith('_'):
+            if not name.startswith('_') and name != "RGB": # there's probably a better way than this to avoid the methods
                 value = getattr(self, name)
                 setattr(self, name, code_to_chars(value))
 
@@ -66,6 +66,10 @@ class AnsiFore(AnsiCodes):
     LIGHTMAGENTA_EX = 95
     LIGHTCYAN_EX    = 96
     LIGHTWHITE_EX   = 97
+    
+    def RGB(self, r, g, b):
+        return CSI + "38;2;" + str(r) + ";" + str(g) + ";" + str(b) + "m"
+        
 
 
 class AnsiBack(AnsiCodes):
@@ -88,6 +92,9 @@ class AnsiBack(AnsiCodes):
     LIGHTMAGENTA_EX = 105
     LIGHTCYAN_EX    = 106
     LIGHTWHITE_EX   = 107
+    
+    def RGB(self, r, g, b):
+        return CSI + "48;2;" + str(r) + ";" + str(g) + ";" + str(b) + "m"
 
 
 class AnsiStyle(AnsiCodes):
@@ -95,6 +102,11 @@ class AnsiStyle(AnsiCodes):
     DIM       = 2
     NORMAL    = 22
     RESET_ALL = 0
+    UNDERLINE = 4
+    #NOTUNDERLINE=24 # Poor naming
+    NEGATIVE  = 7 # called 'Reverse' on wikipedia
+    #POSITIVE = 27 # called 'Not Reversed' on wikipedia
+    
 
 Fore   = AnsiFore()
 Back   = AnsiBack()


### PR DESCRIPTION
add UNDERLINE, and NEGATIVE support to the `AnsiStyle` class,

add RGB methods to `AnsiBack` and `AnsiFore` classes

tested RGB functions using:
```python
import colorama
from colorama import Fore, Back, Style, Cursor

colorama.just_fix_windows_console()

for r in range(0,256,15):
  for g in range(0,256,15):
    b=0
    print(Fore.RGB(256-r,256-g,255)+Back.RGB(r,g,b)+f"({r:3} {g:3})", end="")
  print()

print(Style.RESET_ALL, end="")
```
Result on win10:
![image](https://user-images.githubusercontent.com/102250465/196433253-28d09096-924a-4a91-8ed5-a7a3f58c5b5b.png)
