### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-2.7", "pypy-3.8", "2.7", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-2.7", "pypy-3.8", "2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Add new helper variables to existing jobs
@@ -22,12 +22,13 @@ jobs:
           - {python-version: "3.8", toxenv: "py38"}
           - {python-version: "3.9", toxenv: "py39"}
           - {python-version: "3.10", toxenv: "py310"}
+          - {python-version: "3.11", toxenv: "py311"}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,7 +38,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ If you find Colorama useful, please |donate| to the authors. Thank you!
 Installation
 ------------
 
-Tested on CPython 2.7, 3.7, 3.8, 3.9 and 3.10 and Pypy 2.7 and 3.8.
+Tested on CPython 2.7, 3.7, 3.8, 3.9, 3.10 and 3.11 and PyPy 2.7 and 3.8.
 
 No requirements other than the standard library.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Terminals",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py27, py37, py38, py39, py310, pypy, pypy3
+envlist = py{27, 37, 38, 39, 310, py, py3}
 
 [testenv]
 deps =


### PR DESCRIPTION
Fixes https://github.com/tartley/colorama/issues/360.

Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk).

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)