### PR TITLE
Support python-2.7 in enable_vt_processing

### DIFF
--- a/colorama/winterm.py
+++ b/colorama/winterm.py
@@ -190,6 +190,6 @@ def enable_vt_processing(fd):
         mode = win32.GetConsoleMode(handle)
         if mode & win32.ENABLE_VIRTUAL_TERMINAL_PROCESSING:
             return True
-    # Can get TypeError in testsuite where 'fd' is a Mock()
-    except (OSError, TypeError):
+    # Can get TypeError in testsuite where 'fd' is a Mock() and IOError in python2.7
+    except (IOError, OSError, TypeError):
         return False


### PR DESCRIPTION
This fixes an issue present in `colorama-0.4.6` when run in `python-2.7` on `msys` or `git-bash` terminals (such as `mintty`).  In such a case the following error has been observed
```
  File "C:\...\.venv\lib\site-packages\click\core.py", line 950, in show_help
    echo(ctx.get_help(), color=ctx.color)
  File "C:\...\.venv\lib\site-packages\click\utils.py", line 267, in echo
    file = auto_wrap_for_ansi(file)
  File "C:\...\.venv\lib\site-packages\click\_compat.py", line 704, in auto_wrap_for_ansi
    ansi_wrapper = colorama.AnsiToWin32(stream, strip=strip)
  File "C:\...\.venv\lib\site-packages\colorama\ansitowin32.py", line 101, in __init__
    system_has_native_ansi = not on_windows or enable_vt_processing(fd)
  File "C:\...\.venv\lib\site-packages\colorama\winterm.py", line 183, in enable_vt_processing
    handle = get_osfhandle(fd)
IOError: [Errno 9] Bad file descriptor
```

Note that this does **not** occur in `python-3`, as in such a case an `IOError` is really an `OSError` and is then caught.