### PR TITLE
RGB and Hex integrated

### DIFF
--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -23,15 +23,41 @@ def clear_line(mode=2):
 
 
 class AnsiCodes(object):
+
     def __init__(self):
         # the subclasses declare class attributes which are numbers.
         # Upon instantiation we define instance attributes, which are the same
         # as the class attributes but wrapped with the ANSI escape sequence
         for name in dir(self):
-            if not name.startswith('_'):
+            if not name.startswith('_') and not name == 'from_rgb' and not name == 'from_hex':
                 value = getattr(self, name)
                 setattr(self, name, code_to_chars(value))
 
+    @staticmethod
+    def from_rgb(r, g, b):
+
+        return f'\033[38;2;{r};{g};{b}m'
+
+    @staticmethod
+    def from_hex(hex: str):
+
+        hex = hex.strip('#')
+
+        if len(hex) == 6:
+
+            rgb = tuple(int(single_hex, 16) for single_hex in (hex[0:2], hex[2:4], hex[4:6]))
+
+            return AnsiCodes.from_rgb(*rgb)
+
+        elif len(hex) == 3:
+
+            rgb = tuple(int(single_hex, 16) for single_hex in (hex[0]*2, hex[1]*2, hex[2]*2))
+
+            return AnsiCodes.from_rgb(*rgb)
+
+        else:
+
+            raise ValueError(f'Hex Error: The given hex code: {hex} is not valid. A hex code should be 6 or 3 characters long.')
 
 class AnsiCursor(object):
     def UP(self, n=1):

--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -33,31 +33,53 @@ class AnsiCodes(object):
                 value = getattr(self, name)
                 setattr(self, name, code_to_chars(value))
 
-    @staticmethod
-    def from_rgb(r, g, b):
+    @classmethod
+    def from_rgb(cls, r, g, b):
 
-        return f'\033[38;2;{r};{g};{b}m'
+        if cls == AnsiFore:
 
-    @staticmethod
-    def from_hex(hex: str):
+            ansi_start = '38'
+
+        elif cls == AnsiBack:
+
+            ansi_start = '48'
+
+        else:
+
+            raise TypeError('The from_hex command may only be called from AnsiFore and AnsiBack objects.')
+
+        return f'\033[{ansi_start};2;{r};{g};{b}m'
+
+    @classmethod
+    def from_hex(cls, hex: str):
 
         hex = hex.strip('#')
 
         if len(hex) == 6:
 
-            rgb = tuple(int(single_hex, 16) for single_hex in (hex[0:2], hex[2:4], hex[4:6]))
-
-            return AnsiCodes.from_rgb(*rgb)
+            r, g, b = tuple(int(single_hex, 16) for single_hex in (hex[0:2], hex[2:4], hex[4:6]))
 
         elif len(hex) == 3:
 
-            rgb = tuple(int(single_hex, 16) for single_hex in (hex[0]*2, hex[1]*2, hex[2]*2))
-
-            return AnsiCodes.from_rgb(*rgb)
+            r, g, b = tuple(int(single_hex, 16) for single_hex in (hex[0]*2, hex[1]*2, hex[2]*2))
 
         else:
 
             raise ValueError(f'Hex Error: The given hex code: {hex} is not valid. A hex code should be 6 or 3 characters long.')
+
+        if cls == AnsiFore:
+
+            ansi_start = '38'
+
+        elif cls == AnsiBack:
+
+            ansi_start = '48'
+
+        else:
+
+            raise TypeError('The from_hex command may only be called from AnsiFore and AnsiBack objects.')
+
+        return f'\033[{ansi_start};2;{r};{g};{b}m'
 
 class AnsiCursor(object):
     def UP(self, n=1):


### PR DESCRIPTION
I added two new commands: "from_rgb" and "from_hex". Both of them work on the colorama.ansi.AnsiFore and colorama.ansi.AnsiBack classes. It works as expected with no issues. Tested only however in windows terminal.