### PR TITLE
Fix deprecated actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "PIP_DIR=dir::$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ steps.pip-cache.outputs.PIP_DIR }}
           key:
             ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('**/tox.ini') }}
           restore-keys: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -35,7 +38,7 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "PIP_DIR=dir::$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "PIP_DIR=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -37,6 +34,7 @@ jobs:
 
       - name: Get pip cache dir
         id: pip-cache
+        shell: bash
         run: |
           echo "PIP_DIR=$(pip cache dir)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Fix deprecation warning "The `set-output` command is deprecated and will be disabled soon" on `jobs.test.steps.pip-cache` by redirecting the output of the echo command to `$GITHUB_ACTIONS` and by using the shell bash to avoid the command not working on Windows default shell.

At first, I was going to submit the PR by using the shell bash not only in that specific step but after thinking about it I only used it on that specific step as using the bash shell in the tox execution step could break everything.