### PR TITLE
ci/lint: convert lints to pre-commit & Ruff

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,24 +1,12 @@
-name: lint_python
+name: pre-commit checks
 on: [pull_request, push]
 jobs:
-  lint_python:
+  precommit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install --upgrade pip wheel
-      - run: pip install bandit black codespell flake8 flake8-bugbear
-                         flake8-comprehensions isort mypy pytest pyupgrade safety
-      - run: bandit --recursive --skip B311 .
-      - run: black --check . || true
-      - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
-                      --show-source --statistics
-      - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt
-      - run: mkdir --parents --verbose .mypy_cache
-      - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
-      - run: pytest .
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
-      - run: safety check
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+      - run: pip install safety
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,54 @@
+default_language_version:
+  python: python3
+
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
+  autoupdate_schedule: quarterly
+  # submodules: true
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-toml
+      - id: check-case-conflict
+      - id: detect-private-key
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
+        args: ["--write-changes"]
+        exclude: pyproject.toml
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
+    hooks:
+      # try to fix what is possible
+      - id: ruff
+        args: ["--fix"]
+      # perform formatting updates
+      - id: ruff-format
+      # validate if all is fine with preview mode
+      - id: ruff
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+        always_run: true
+        pass_filenames: false
+
+  - repo: local
+    hooks:
+      - id: python-safety-dependencies-check
+        name: safety
+        entry: safety
+        args: ["check", "--full-report", "--file"]
+        language: system
+        files: requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,39 @@ include = [
 include = [
     "/colorama/*",
 ]
+
+
+[tool.ruff]
+target-version = "py37"
+#line-length = 120
+
+[tool.ruff.format]
+preview = true
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "W", # see: https://pypi.org/project/pycodestyle
+    "F", # see: https://pypi.org/project/pyflakes
+    "I", #see: https://pypi.org/project/isort/
+    "S", # see: https://pypi.org/project/flake8-bandit
+    "UP", # see: https://docs.astral.sh/ruff/rules/#pyupgrade-up
+]
+extend-select = [
+    "B",    # see: https://pypi.org/project/flake8-bugbear
+    "C4",   # see: https://pypi.org/project/flake8-comprehensions
+]
+ignore-init-module-imports = true
+unfixable = ["F401"]
+
+[tool.ruff.lint.pydocstyle]
+# Use Google-style docstrings.
+convention = "google"
+
+[tool.ruff.lint.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10
+
+[tool.codespell]
+#skip = '*.py'
+quiet-level = 3


### PR DESCRIPTION
simplify the linting with easier-to-read pre-commit, which can also be installed as a bot (which may commit linting fixes to open PRs)
With his pre-commit, we also explicitly set used versions, so there are sudden issues due to the recently released new linter version
Moreover, wrapping several linters and formatted to Ruff rule, which is a much faster tool:
- `flake8` -> rule 'E', 'F', 'W'
- `isort` -> rule 'I'
- `pyupgrade` -> rule 'UP'
- `bandit` -> rule 'S'
- `bugbear` -> rule 'B'
- `comprehensions` -> rule 'C4'

cc: @tartley @hugovk 