### PR TITLE
Support colors in jupyter notebooks.

### DIFF
--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -51,6 +51,9 @@ class StreamWrapper(object):
         if 'PYCHARM_HOSTED' in os.environ:
             if stream is not None and (stream is sys.__stdout__ or stream is sys.__stderr__):
                 return True
+        # Detect if we are running in a jupyter notebook which supports ANSI colors
+        elif "JPY_PARENT_PID" in os.environ:
+            return False
         try:
             stream_isatty = stream.isatty
         except AttributeError:


### PR DESCRIPTION
This PR adds color support to colorama when running in jupyter notebooks.

See also:
https://github.com/gruns/icecream/issues/100
https://github.com/gruns/icecream/pull/112