### PR TITLE
Fix just_fix_windows_console to use the StreamWrapper

### DIFF
--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -85,10 +85,10 @@ def just_fix_windows_console():
     # replace sys.stdout/stderr if we're in the old-style conversion mode.
     new_stdout = AnsiToWin32(sys.stdout, convert=None, strip=None, autoreset=False)
     if new_stdout.convert:
-        sys.stdout = new_stdout
+        sys.stdout = new_stdout.stream
     new_stderr = AnsiToWin32(sys.stderr, convert=None, strip=None, autoreset=False)
     if new_stderr.convert:
-        sys.stderr = new_stderr
+        sys.stderr = new_stderr.stream
 
     fixed_windows_console = True
 


### PR DESCRIPTION
The AnsiToWin32 class is not meant to be used as a file proxy directly, although it does define the write method, but it defines a `stream` member of type StreamWrapper which forwards/intercepts all the file operations as appropriate. In `init` which calls `wrap_stream` this underlying stream object is assigned to sys.stdout/stderr, but the `just_fix_windows_console` function instead assigns the AnsiToWin32 instance directly, which will break trying to use any other methods than `write` on the standard streams.

This change fixes the behavior of `just_fix_windows_console` to use the StreamWrapper object as in `init`.