### PR TITLE
Drop support for EOL Python 2.7-3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-2.7", "pypy-3.8", "2.7", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Add new helper variables to existing jobs
-          - {python-version: "pypy-2.7", toxenv: "pypy"}
           - {python-version: "pypy-3.8", toxenv: "pypy3"}
-          - {python-version: "2.7", toxenv: "py27"}
           - {python-version: "3.7", toxenv: "py37"}
           - {python-version: "3.8", toxenv: "py38"}
           - {python-version: "3.9", toxenv: "py39"}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy-3.8", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Add new helper variables to existing jobs
           - {python-version: "pypy-3.8", toxenv: "pypy3"}
-          - {python-version: "3.7", toxenv: "py37"}
           - {python-version: "3.8", toxenv: "py38"}
           - {python-version: "3.9", toxenv: "py39"}
           - {python-version: "3.10", toxenv: "py310"}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy-3.11", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Add new helper variables to existing jobs
-          - {python-version: "pypy-3.8", toxenv: "pypy3"}
-          - {python-version: "3.8", toxenv: "py38"}
+          - {python-version: "pypy-3.11", toxenv: "pypy3"}
           - {python-version: "3.9", toxenv: "py39"}
           - {python-version: "3.10", toxenv: "py310"}
           - {python-version: "3.11", toxenv: "py311"}

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ If you find Colorama useful, please |donate| to the authors. Thank you!
 Installation
 ------------
 
-Tested on CPython 2.7, 3.7, 3.8, 3.9, 3.10, 3.11 and 3.12 and PyPy 2.7 and 3.8.
+Tested on CPython 3.7, 3.8, 3.9, 3.10, 3.11 and 3.12 and PyPy 3.8.
 
 No requirements other than the standard library.
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ If you find Colorama useful, please |donate| to the authors. Thank you!
 Installation
 ------------
 
-Tested on CPython 3.8, 3.9, 3.10, 3.11 and 3.12 and PyPy 3.8.
+Tested on CPython 3.9, 3.10, 3.11, 3.12, 3.13 and PyPy 3.11.
 
 No requirements other than the standard library.
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ If you find Colorama useful, please |donate| to the authors. Thank you!
 Installation
 ------------
 
-Tested on CPython 3.7, 3.8, 3.9, 3.10, 3.11 and 3.12 and PyPy 3.8.
+Tested on CPython 3.8, 3.9, 3.10, 3.11 and 3.12 and PyPy 3.8.
 
 No requirements other than the standard library.
 

--- a/README.rst
+++ b/README.rst
@@ -257,10 +257,6 @@ init(wrap=True):
         init(wrap=False)
         stream = AnsiToWin32(sys.stderr).stream
 
-        # Python 2
-        print >>stream, Fore.BLUE + 'blue text on stderr'
-
-        # Python 3
         print(Fore.BLUE + 'blue text on stderr', file=stream)
 
 Recognised ANSI Sequences

--- a/colorama/ansi.py
+++ b/colorama/ansi.py
@@ -22,7 +22,7 @@ def clear_line(mode=2):
     return CSI + str(mode) + 'K'
 
 
-class AnsiCodes(object):
+class AnsiCodes:
     def __init__(self):
         # the subclasses declare class attributes which are numbers.
         # Upon instantiation we define instance attributes, which are the same
@@ -33,7 +33,7 @@ class AnsiCodes(object):
                 setattr(self, name, code_to_chars(value))
 
 
-class AnsiCursor(object):
+class AnsiCursor:
     def UP(self, n=1):
         return CSI + str(n) + 'A'
     def DOWN(self, n=1):

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -13,7 +13,7 @@ if windll is not None:
     winterm = WinTerm()
 
 
-class StreamWrapper(object):
+class StreamWrapper:
     '''
     Wraps a stream (such as stdout), acting as a transparent proxy for all
     attribute access apart from method 'write()', which is delegated to our
@@ -69,7 +69,7 @@ class StreamWrapper(object):
             return True
 
 
-class AnsiToWin32(object):
+class AnsiToWin32:
     '''
     Implements a 'write()' method which, on Windows, will strip ANSI character
     sequences from the text, and if outputting to a tty, will convert them into

--- a/colorama/initialise.py
+++ b/colorama/initialise.py
@@ -21,12 +21,8 @@ def _wipe_internal_state_for_tests():
     global fixed_windows_console
     fixed_windows_console = False
 
-    try:
-        # no-op if it wasn't registered
-        atexit.unregister(reset_all)
-    except AttributeError:
-        # python 2: no atexit.unregister. Oh well, we did our best.
-        pass
+    # no-op if it wasn't registered
+    atexit.unregister(reset_all)
 
 
 def reset_all():

--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -1,16 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 from io import StringIO, TextIOWrapper
 from unittest import TestCase, main
-try:
-    from contextlib import ExitStack
-except ImportError:
-    # python 2
-    from contextlib2 import ExitStack
-
-try:
-    from unittest.mock import MagicMock, Mock, patch
-except ImportError:
-    from mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
+from contextlib import ExitStack
 
 from ..ansitowin32 import AnsiToWin32, StreamWrapper
 from ..win32 import ENABLE_VIRTUAL_TERMINAL_PROCESSING
@@ -35,7 +27,7 @@ class StreamWrapperTest(TestCase):
         mockConverter = Mock()
         s = StringIO()
         with StreamWrapper(s, mockConverter) as fp:
-            fp.write(u'hello')
+            fp.write('hello')
         self.assertTrue(s.closed)
 
     def testProxyNoContextManager(self):

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -1,11 +1,7 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 import sys
 from unittest import TestCase, main, skipUnless
-
-try:
-    from unittest.mock import patch, Mock
-except ImportError:
-    from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from ..ansitowin32 import StreamWrapper
 from ..initialise import init, just_fix_windows_console, _wipe_internal_state_for_tests

--- a/colorama/tests/winterm_test.py
+++ b/colorama/tests/winterm_test.py
@@ -1,11 +1,7 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 import sys
 from unittest import TestCase, main, skipUnless
-
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from ..winterm import WinColor, WinStyle, WinTerm
 

--- a/colorama/winterm.py
+++ b/colorama/winterm.py
@@ -9,7 +9,7 @@ except ImportError:
 from . import win32
 
 # from wincon.h
-class WinColor(object):
+class WinColor:
     BLACK   = 0
     BLUE    = 1
     GREEN   = 2
@@ -20,12 +20,12 @@ class WinColor(object):
     GREY    = 7
 
 # from wincon.h
-class WinStyle(object):
+class WinStyle:
     NORMAL              = 0x00 # dim text, dim background
     BRIGHT              = 0x08 # bright text, dim background
     BRIGHT_BACKGROUND   = 0x80 # dim text, bright background
 
-class WinTerm(object):
+class WinTerm:
 
     def __init__(self):
         self._default = win32.GetConsoleScreenBufferInfo(win32.STDOUT).wAttributes
@@ -191,5 +191,5 @@ def enable_vt_processing(fd):
         if mode & win32.ENABLE_VIRTUAL_TERMINAL_PROCESSING:
             return True
     # Can get TypeError in testsuite where 'fd' is a Mock() and IOError in python2.7
-    except (IOError, OSError, TypeError):
+    except (OSError, TypeError):
         return False

--- a/demos/demo01.py
+++ b/demos/demo01.py
@@ -4,7 +4,6 @@
 # print grid of all colors and brightnesses
 # uses stdout.write to write chars with no newline nor spaces between them
 # This should run more-or-less identically on Windows and Unix.
-from __future__ import print_function
 import sys
 
 # Add parent dir to sys path, so the following 'import colorama' always finds

--- a/demos/demo02.py
+++ b/demos/demo02.py
@@ -3,7 +3,6 @@
 
 # Simple demo of changing foreground, background and brightness.
 
-from __future__ import print_function
 import fixpath
 from colorama import just_fix_windows_console, Fore, Back, Style
 

--- a/demos/demo03.py
+++ b/demos/demo03.py
@@ -3,7 +3,6 @@
 
 # Demonstrate the different behavior when autoreset is True and False.
 
-from __future__ import print_function
 import fixpath
 from colorama import init, Fore, Back, Style
 

--- a/demos/demo04.py
+++ b/demos/demo04.py
@@ -2,7 +2,6 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 
 # check that stripped ANSI in redirected stderr does not affect stdout
-from __future__ import print_function
 import sys
 import fixpath
 from colorama import init, Fore

--- a/demos/demo05.py
+++ b/demos/demo05.py
@@ -5,7 +5,6 @@
 # The point of the demonstration is to show how the ANSI wrapping on Windows can be disabled.
 # The unwrapped cases will be interpreted with ANSI on Unix, but not on Windows.
 
-from __future__ import print_function
 import sys
 import fixpath
 from colorama import AnsiToWin32, init, Fore

--- a/demos/demo06.py
+++ b/demos/demo06.py
@@ -1,5 +1,4 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
-from __future__ import print_function
 import fixpath
 import colorama
 from colorama import Fore, Back, Style, Cursor

--- a/demos/demo07.py
+++ b/demos/demo07.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import fixpath
 import colorama
 

--- a/demos/demo08.py
+++ b/demos/demo08.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import fixpath
 from colorama import colorama_text, Fore
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "colorama"
 description = "Cross-platform colored terminal text."
 readme = "README.rst"
 license = "BSD-3-Clause"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Jonathan Hartley", email = "tartley@tartley.com" },
 ]
@@ -32,7 +32,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "colorama"
 description = "Cross-platform colored terminal text."
 readme = "README.rst"
 license = "BSD-3-Clause"
-requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+requires-python = ">=3.7"
 authors = [
     { name = "Jonathan Hartley", email = "tartley@tartley.com" },
 ]
@@ -30,8 +30,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "colorama"
 description = "Cross-platform colored terminal text."
 readme = "README.rst"
 license = "BSD-3-Clause"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Jonathan Hartley", email = "tartley@tartley.com" },
 ]
@@ -32,7 +32,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,3 @@
-mock>=1.0.1;python_version<"3.3"
 twine>=3.1.1
-contextlib2;python_version<"3"
 build
 -e .

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{27, 37, 38, 39, 310, 311, 312, 313, py, py3}
+envlist = py{37, 38, 39, 310, 311, 312, 313, py3}
 
 [testenv]
-deps =
-  py27,pypy: mock
-  py27,pypy: contextlib2
 commands = python -m unittest discover -p *_test.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{38, 39, 310, 311, 312, 313, py3}
+envlist = py{39, 310, 311, 312, 313, py3}
 
 [testenv]
 commands = python -m unittest discover -p *_test.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{37, 38, 39, 310, 311, 312, 313, py3}
+envlist = py{38, 39, 310, 311, 312, 313, py3}
 
 [testenv]
 commands = python -m unittest discover -p *_test.py


### PR DESCRIPTION
Follow on from https://github.com/tartley/colorama/pull/403#discussion_r2190489805

Python 2.7-3.8 are EOL:

<img width="758" alt="image" src="https://github.com/user-attachments/assets/b9e9c5ba-925a-4b7c-b142-347c26d97b86" />

https://devguide.python.org/versions/

2.7 and 3.7 are also no longer available on GitHub Actions causing the CI to fail. This PR also takes the opportunity to drop EOL 3.8.

This allows future improvements such as f-strings.