### PR TITLE
Bumping major version number due to compatibility break

### DIFF
--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -3,5 +3,5 @@ from .initialise import init, deinit, reinit, colorama_text, just_fix_windows_co
 from .ansi import Fore, Back, Style, Cursor
 from .ansitowin32 import AnsiToWin32
 
-__version__ = '0.4.7dev1'
+__version__ = '1.0.0dev1'
 


### PR DESCRIPTION
Bumping to 1.0 to indicate we're breaking backward compatibility by a recent merge dropping support for older End-of-lifed versions of Python (2.7, 3.7, 3.8).

We probably still run on those, for now, but github CI no longer supports them, so we aren't systematically running tests against them.