### PR TITLE
Replace lint tools with Ruff

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,6 +1,18 @@
 name: lint_python
 on: [pull_request, push]
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - uses: tox-dev/action-pre-commit-uv@v1
+
   lint_python:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -24,7 +24,6 @@ jobs:
       - run: bandit --recursive --skip B311 .
       - run: black --check . || true
       - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
                       --show-source --statistics
       - run: isort --check-only --profile black . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,5 +1,5 @@
-name: lint_python
-on: [pull_request, push]
+name: lint
+on: [pull_request, push, workflow_dispatch]
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -19,11 +19,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - run: pip install --upgrade pip
-      - run: pip install black codespell flake8 flake8-bugbear
-                         mypy pytest
+      - run: pip install black codespell flake8 flake8-bugbear mypy
       - run: black --check . || true
       - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
       - run: pip install -r requirements.txt
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
-      - run: pytest .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-bugbear
-                         isort mypy pytest pyupgrade
+                         isort mypy pytest
       - run: bandit --recursive --skip B311 .
       - run: black --check . || true
       - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
@@ -29,4 +29,3 @@ jobs:
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest .
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-bugbear
-                         flake8-comprehensions isort mypy pytest pyupgrade
+                         isort mypy pytest pyupgrade
       - run: bandit --recursive --skip B311 .
       - run: black --check . || true
       - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -18,12 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - run: pip install --upgrade pip wheel
+      - run: pip install --upgrade pip
       - run: pip install black codespell flake8 flake8-bugbear
-                         isort mypy pytest
+                         mypy pytest
       - run: black --check . || true
       - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
-      - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -19,9 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - run: pip install --upgrade pip wheel
-      - run: pip install bandit black codespell flake8 flake8-bugbear
+      - run: pip install black codespell flake8 flake8-bugbear
                          isort mypy pytest
-      - run: bandit --recursive --skip B311 .
       - run: black --check . || true
       - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
       - run: isort --check-only --profile black . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-python@v5
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-bugbear
-                         flake8-comprehensions isort mypy pytest pyupgrade safety
+                         flake8-comprehensions isort mypy pytest pyupgrade
       - run: bandit --recursive --skip B311 .
       - run: black --check . || true
       - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
@@ -21,4 +21,3 @@ jobs:
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest .
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
-      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -24,8 +24,6 @@ jobs:
       - run: bandit --recursive --skip B311 .
       - run: black --check . || true
       - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
-                      --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt
       - run: mkdir --parents --verbose .mypy_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.3
+    hooks:
+      - id: ruff-check
+        args: [--exit-non-zero-on-fix]

--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
-from .initialise import init, deinit, reinit, colorama_text, just_fix_windows_console
-from .ansi import Fore, Back, Style, Cursor
+from .ansi import Back, Cursor, Fore, Style
 from .ansitowin32 import AnsiToWin32
+from .initialise import colorama_text, deinit, init, just_fix_windows_console, reinit
 
 __version__ = '0.4.7dev1'
 

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -1,12 +1,11 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+import os
 import re
 import sys
-import os
 
-from .ansi import AnsiFore, AnsiBack, AnsiStyle, Style, BEL
-from .winterm import enable_vt_processing, WinTerm, WinColor, WinStyle
-from .win32 import windll, winapi_test
-
+from .ansi import BEL, AnsiBack, AnsiFore, AnsiStyle, Style
+from .win32 import winapi_test, windll
+from .winterm import WinColor, WinStyle, WinTerm, enable_vt_processing
 
 winterm = None
 if windll is not None:

--- a/colorama/ansitowin32.py
+++ b/colorama/ansitowin32.py
@@ -170,7 +170,7 @@ class AnsiToWin32:
                 AnsiBack.LIGHTCYAN_EX: (winterm.back, WinColor.CYAN, True),
                 AnsiBack.LIGHTWHITE_EX: (winterm.back, WinColor.GREY, True),
             }
-        return dict()
+        return {}
 
     def write(self, text):
         if self.strip or self.convert:
@@ -242,7 +242,7 @@ class AnsiToWin32:
                     func_args = self.win32_calls[param]
                     func = func_args[0]
                     args = func_args[1:]
-                    kwargs = dict(on_stderr=self.on_stderr)
+                    kwargs = {'on_stderr': self.on_stderr}
                     func(*args, **kwargs)
         elif command in 'J':
             winterm.erase_screen(params[0], on_stderr=self.on_stderr)

--- a/colorama/tests/ansitowin32_test.py
+++ b/colorama/tests/ansitowin32_test.py
@@ -1,8 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+from contextlib import ExitStack
 from io import StringIO, TextIOWrapper
 from unittest import TestCase, main
 from unittest.mock import MagicMock, Mock, patch
-from contextlib import ExitStack
 
 from ..ansitowin32 import AnsiToWin32, StreamWrapper
 from ..win32 import ENABLE_VIRTUAL_TERMINAL_PROCESSING

--- a/colorama/tests/initialise_test.py
+++ b/colorama/tests/initialise_test.py
@@ -1,10 +1,10 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 import sys
 from unittest import TestCase, main, skipUnless
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from ..ansitowin32 import StreamWrapper
-from ..initialise import init, just_fix_windows_console, _wipe_internal_state_for_tests
+from ..initialise import _wipe_internal_state_for_tests, init, just_fix_windows_console
 from .utils import osname, replace_by
 
 orig_stdout = sys.stdout

--- a/colorama/tests/isatty_test.py
+++ b/colorama/tests/isatty_test.py
@@ -2,8 +2,8 @@
 import sys
 from unittest import TestCase, main
 
-from ..ansitowin32 import StreamWrapper, AnsiToWin32
-from .utils import pycharm, replace_by, replace_original_by, StreamTTY, StreamNonTTY
+from ..ansitowin32 import AnsiToWin32, StreamWrapper
+from .utils import StreamNonTTY, StreamTTY, pycharm, replace_by, replace_original_by
 
 
 def is_a_tty(stream):

--- a/colorama/tests/utils.py
+++ b/colorama/tests/utils.py
@@ -1,8 +1,8 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
+import os
+import sys
 from contextlib import contextmanager
 from io import StringIO
-import sys
-import os
 
 
 class StreamTTY(StringIO):

--- a/colorama/win32.py
+++ b/colorama/win32.py
@@ -16,7 +16,7 @@ except (AttributeError, ImportError):
     SetConsoleTextAttribute = lambda *_: None
     winapi_test = lambda *_: None
 else:
-    from ctypes import byref, Structure, c_char, POINTER
+    from ctypes import POINTER, Structure, byref, c_char
 
     COORD = wintypes._COORD
 

--- a/colorama/win32.py
+++ b/colorama/win32.py
@@ -30,12 +30,12 @@ else:
             ("dwMaximumWindowSize", COORD),
         ]
         def __str__(self):
-            return '(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)' % (
-                self.dwSize.Y, self.dwSize.X
-                , self.dwCursorPosition.Y, self.dwCursorPosition.X
-                , self.wAttributes
-                , self.srWindow.Top, self.srWindow.Left, self.srWindow.Bottom, self.srWindow.Right
-                , self.dwMaximumWindowSize.Y, self.dwMaximumWindowSize.X
+            return (
+                f"({self.dwSize.Y},{self.dwSize.X},"
+                f"{self.dwCursorPosition.Y},{self.dwCursorPosition.X},"
+                f"{self.wAttributes},"
+                f"{self.srWindow.Top},{self.srWindow.Left},{self.srWindow.Bottom},{self.srWindow.Right},"
+                f"{self.dwMaximumWindowSize.Y},{self.dwMaximumWindowSize.X})"
             )
 
     _GetStdHandle = windll.kernel32.GetStdHandle

--- a/colorama/winterm.py
+++ b/colorama/winterm.py
@@ -8,6 +8,7 @@ except ImportError:
 
 from . import win32
 
+
 # from wincon.h
 class WinColor:
     BLACK   = 0

--- a/demos/demo01.py
+++ b/demos/demo01.py
@@ -9,7 +9,8 @@ import sys
 # Add parent dir to sys path, so the following 'import colorama' always finds
 # the local source in preference to any installed version of colorama.
 import fixpath
-from colorama import just_fix_windows_console, Fore, Back, Style
+
+from colorama import Back, Fore, Style, just_fix_windows_console
 
 just_fix_windows_console()
 

--- a/demos/demo01.py
+++ b/demos/demo01.py
@@ -29,18 +29,18 @@ NAMES = {
 # show the color names
 sys.stdout.write('        ')
 for foreground in FORES:
-    sys.stdout.write('%s%-7s' % (foreground, NAMES[foreground]))
+    sys.stdout.write(f'{foreground}{NAMES[foreground]:<7}')
 print()
 
 # make a row for each background color
 for background in BACKS:
-    sys.stdout.write('%s%-7s%s %s' % (background, NAMES[background], Back.RESET, background))
+    sys.stdout.write(f'{background}{NAMES[background]:<7}{Back.RESET} {background}')
     # make a column for each foreground color
     for foreground in FORES:
         sys.stdout.write(foreground)
         # show dim, normal bright
         for brightness in STYLES:
-            sys.stdout.write('%sX ' % brightness)
+            sys.stdout.write(f'{brightness}X ')
         sys.stdout.write(Style.RESET_ALL + ' ' + background)
     print(Style.RESET_ALL)
 

--- a/demos/demo02.py
+++ b/demos/demo02.py
@@ -4,7 +4,8 @@
 # Simple demo of changing foreground, background and brightness.
 
 import fixpath
-from colorama import just_fix_windows_console, Fore, Back, Style
+
+from colorama import Back, Fore, Style, just_fix_windows_console
 
 just_fix_windows_console()
 

--- a/demos/demo03.py
+++ b/demos/demo03.py
@@ -4,7 +4,8 @@
 # Demonstrate the different behavior when autoreset is True and False.
 
 import fixpath
-from colorama import init, Fore, Back, Style
+
+from colorama import Back, Fore, Style, init
 
 init(autoreset=True)
 print(Fore.CYAN + Back.MAGENTA + Style.BRIGHT + 'Line 1: colored, with autoreset=True')

--- a/demos/demo04.py
+++ b/demos/demo04.py
@@ -3,8 +3,10 @@
 
 # check that stripped ANSI in redirected stderr does not affect stdout
 import sys
+
 import fixpath
-from colorama import init, Fore
+
+from colorama import Fore, init
 
 init()
 print(Fore.GREEN + 'GREEN set on stdout. ', end='')

--- a/demos/demo05.py
+++ b/demos/demo05.py
@@ -6,8 +6,10 @@
 # The unwrapped cases will be interpreted with ANSI on Unix, but not on Windows.
 
 import sys
+
 import fixpath
-from colorama import AnsiToWin32, init, Fore
+
+from colorama import AnsiToWin32, Fore, init
 
 init()
 print(f'{Fore.YELLOW}Wrapped yellow going to stdout, via the default print function.')

--- a/demos/demo05.py
+++ b/demos/demo05.py
@@ -10,12 +10,12 @@ import fixpath
 from colorama import AnsiToWin32, init, Fore
 
 init()
-print('%sWrapped yellow going to stdout, via the default print function.' % Fore.YELLOW)
+print(f'{Fore.YELLOW}Wrapped yellow going to stdout, via the default print function.')
 
 init(wrap=False)
-print('%sUnwrapped CYAN going to stdout, via the default print function.' % Fore.CYAN)
-print('%sUnwrapped CYAN, using the file parameter to write via colorama the AnsiToWin32 function.' % Fore.CYAN, file=AnsiToWin32(sys.stdout))
-print('%sUnwrapped RED going to stdout, via the default print function.' % Fore.RED)
+print(f'{Fore.CYAN}Unwrapped CYAN going to stdout, via the default print function.')
+print(f'{Fore.CYAN}Unwrapped CYAN, using the file parameter to write via colorama the AnsiToWin32 function.', file=AnsiToWin32(sys.stdout))
+print(f'{Fore.RED}Unwrapped RED going to stdout, via the default print function.')
 
 init()
-print('%sWrapped RED going to stdout, via the default print function.' % Fore.RED)
+print(f'{Fore.RED}Wrapped RED going to stdout, via the default print function.')

--- a/demos/demo06.py
+++ b/demos/demo06.py
@@ -27,15 +27,15 @@ def main():
     pos = lambda y, x: Cursor.POS(x, y)
     # draw a white border.
     print(Back.WHITE, end='')
-    print('%s%s' % (pos(MINY, MINX), ' '*MAXX), end='')
+    print('{}{}'.format(pos(MINY, MINX), ' '*MAXX), end='')
     for y in range(MINY, 1+MAXY):
-        print('%s %s ' % (pos(y, MINX), pos(y, MAXX)), end='')
-    print('%s%s' % (pos(MAXY, MINX), ' '*MAXX), end='')
+        print(f'{pos(y, MINX)} {pos(y, MAXX)} ', end='')
+    print('{}{}'.format(pos(MAXY, MINX), ' '*MAXX), end='')
     # draw some blinky lights for a while.
     for _ in range(PASSES):
-        print('%s%s%s%s%s' % (pos(randint(1+MINY,MAXY-1), randint(1+MINX,MAXX-1)), choice(FORES), choice(BACKS), choice(STYLES), choice(CHARS)), end='')
+        print(f'{pos(randint(1+MINY,MAXY-1), randint(1+MINX,MAXX-1))}{choice(FORES)}{choice(BACKS)}{choice(STYLES)}{choice(CHARS)}', end='')
     # put cursor to top, left, and set color to white-on-black with normal brightness.
-    print('%s%s%s%s' % (pos(MINY, MINX), Fore.WHITE, Back.BLACK, Style.NORMAL), end='')
+    print(f'{pos(MINY, MINX)}{Fore.WHITE}{Back.BLACK}{Style.NORMAL}', end='')
 
 if __name__ == '__main__':
     main()

--- a/demos/demo06.py
+++ b/demos/demo06.py
@@ -1,9 +1,11 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
-import fixpath
-import colorama
-from colorama import Fore, Back, Style, Cursor
-from random import randint, choice
+from random import choice, randint
 from string import printable
+
+import fixpath
+
+import colorama
+from colorama import Back, Cursor, Fore, Style
 
 # Demonstrate printing colored, random characters at random positions on the screen
 

--- a/demos/demo06.py
+++ b/demos/demo06.py
@@ -32,7 +32,7 @@ def main():
         print('%s %s ' % (pos(y, MINX), pos(y, MAXX)), end='')
     print('%s%s' % (pos(MAXY, MINX), ' '*MAXX), end='')
     # draw some blinky lights for a while.
-    for i in range(PASSES):
+    for _ in range(PASSES):
         print('%s%s%s%s%s' % (pos(randint(1+MINY,MAXY-1), randint(1+MINX,MAXX-1)), choice(FORES), choice(BACKS), choice(STYLES), choice(CHARS)), end='')
     # put cursor to top, left, and set color to white-on-black with normal brightness.
     print('%s%s%s%s' % (pos(MINY, MINX), Fore.WHITE, Back.BLACK, Style.NORMAL), end='')

--- a/demos/demo07.py
+++ b/demos/demo07.py
@@ -1,4 +1,5 @@
 import fixpath
+
 import colorama
 
 # Demonstrate cursor relative movement: UP, DOWN, FORWARD, and BACK in colorama.CURSOR

--- a/demos/demo08.py
+++ b/demos/demo08.py
@@ -1,5 +1,6 @@
 import fixpath
-from colorama import colorama_text, Fore
+
+from colorama import Fore, colorama_text
 
 
 def main():

--- a/demos/demo09.py
+++ b/demos/demo09.py
@@ -6,7 +6,7 @@ import argparse
 parser = argparse.ArgumentParser("colorama demo")
 
 def format(module):
-    return list(map(lambda x: x.lower(),module.__dict__.keys()))
+    return [x.lower() for x in module.__dict__.keys()]
 
 def find(module,item):
     return module.__dict__[item.upper()]

--- a/demos/demo09.py
+++ b/demos/demo09.py
@@ -1,8 +1,10 @@
 # https://www.youtube.com/watch?v=F5a8RLY2N8M&list=PL1_riyn9sOjcKIAYzo7f8drxD-Yg9La-D&index=61
 # Generic colorama demo using command line arguments
 # By George Ogden
-from colorama import Fore, Back, Style, init
 import argparse
+
+from colorama import Back, Fore, Style, init
+
 parser = argparse.ArgumentParser("colorama demo")
 
 def format(module):

--- a/demos/fixpath.py
+++ b/demos/fixpath.py
@@ -3,6 +3,7 @@
 # Add demo dir's parent to sys path, so that 'import colorama' always finds
 # the local source in preference to any installed version of colorama.
 import sys
-from os.path import normpath, dirname, join
+from os.path import dirname, join, normpath
+
 local_colorama_module = normpath(join(dirname(__file__), '..'))
 sys.path.insert(0, local_colorama_module)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ lint.select = [
   "F63",  # Pyflakes
   "F7",   # Pyflakes
   "F82",  # Pyflakes
+  "I",    # isort
   "S",    # flake8-bandit
   "UP",   # pyupgrade
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,13 @@ include = [
 include = [
     "/colorama/*",
 ]
+
+[tool.ruff]
+fix = true
+
+lint.select = [
+  "E9",   # pycodestyle errors
+  "F63",  # Pyflakes
+  "F7",   # Pyflakes
+  "F82",  # Pyflakes
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,9 @@ lint.select = [
   "F63",  # Pyflakes
   "F7",   # Pyflakes
   "F82",  # Pyflakes
+  "S",    # flake8-bandit
   "UP",   # pyupgrade
+]
+lint.ignore = [
+  "S311",   # suspicious-non-cryptographic-random-usage
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ include = [
 fix = true
 
 lint.select = [
+  "C4",   # flake8-comprehensions
   "C90",  # McCabe complexity
   "E9",   # pycodestyle errors
   "F63",  # Pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ include = [
 fix = true
 
 lint.select = [
+  "C90",  # McCabe complexity
   "E9",   # pycodestyle errors
   "F63",  # Pyflakes
   "F7",   # Pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,5 @@ lint.select = [
   "F63",  # Pyflakes
   "F7",   # Pyflakes
   "F82",  # Pyflakes
+  "UP",   # pyupgrade
 ]


### PR DESCRIPTION
Includes https://github.com/tartley/colorama/pull/411.

Re: (2) at https://github.com/tartley/colorama/pull/409#issuecomment-3053398748

This replaces a lot of the lint tools with Ruff.

Some of them had no effect, `|| true` meant they never failed. In this PR, I've applied the changes, for example for isort and pyupgrade.

A follow-up PR can replace some more tools. For example, Black also has `|| true`, so it has quite a lot of formatting to make. We can check this separately because it touches many lines.

The Ruff config is in `pyproject.toml`. I also Ruff to `.pre-commit-config.yaml` for a few reasons:
* it pins the Ruff version so we can upgrade it with intention and don't get surprising failures
* it makes it easy to run it via the CI
* it's easy to add other non-Ruff linting to this file
* those who want to can install the https://pre-commit.com CLI locally and have it run Ruff before committing

